### PR TITLE
Compute DC Total Power for Micro inverters

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Additional groups may be added in the future.
 |AC Phase 3 current|0x4e|`ac/l3/current`|A|string|
 |AC Frequency|0x4f|`ac/freq`|Hz||
 |Operating power|0x50|`operating_power`|W|string, micro|
-|DC total power|0x52|`dc/total_power`|W|string, micro|
+|DC total power|0x52|`dc/total_power`|W|string|
+|DC total power|computed|`dc/total_power`|W|micro|
 |AC apparent power|0x54|`ac/apparent_power`|W|string, micro|
 |AC active power|0x56 - 0x57|`ac/active_power`|W|string, micro|
 |AC reactive power|0x58|`ac/reactive_power`|W|string, micro|
@@ -47,13 +48,16 @@ Additional groups may be added in the future.
 |IGBT temperature|0x5b|`igbt_temp`|C||
 |DC PV1 voltage|0x6d|`dc/pv1/voltage`|V||
 |DC PV1 current|0x6e|`dc/pv1/current`|A||
+|DC PV1 power|computed|`dc/pv1/power`|W||
 |DC PV2 voltage|0x6f|`dc/pv2/voltage`|V||
 |DC PV2 current|0x70|`dc/pv2/current`|A||
+|DC PV2 power|computed|`dc/pv2/power`|W||
 |DC PV3 voltage|0x71|`dc/pv3/voltage`|V||
 |DC PV3 current|0x72|`dc/pv3/current`|A||
+|DC PV3 power|computed|`dc/pv3/power`|W||
 |DC PV4 voltage|0x73|`dc/pv4/voltage`|V||
 |DC PV4 current|0x74|`dc/pv4/current`|A||
-
+|DC PV4 power|computed|`dc/pv4/power`|W||
 
 ## Installation
 1. Copy `config.env.example` as `config.env`

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Additional groups may be added in the future.
 |Operating power|0x50|`operating_power`|W|string, micro|
 |DC total power|0x52|`dc/total_power`|W|string|
 |DC total power|computed|`dc/total_power`|W|micro|
-|AC apparent power|0x54|`ac/apparent_power`|W|string, micro|
+|AC apparent power|0x54|`ac/apparent_power`|W|string|
 |AC active power|0x56 - 0x57|`ac/active_power`|W|string, micro|
-|AC reactive power|0x58|`ac/reactive_power`|W|string, micro|
+|AC reactive power|0x58|`ac/reactive_power`|W|string|
 |Radiator temperature|0x5a|`radiator_temp`|C||
 |IGBT temperature|0x5b|`igbt_temp`|C||
 |DC PV1 voltage|0x6d|`dc/pv1/voltage`|V||

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Additional groups may be added in the future.
 |AC active power|0x56 - 0x57|`ac/active_power`|W|string, micro|
 |AC reactive power|0x58|`ac/reactive_power`|W|string|
 |Radiator temperature|0x5a|`radiator_temp`|C||
-|IGBT temperature|0x5b|`igbt_temp`|C||
+|IGBT temperature|0x5b|`igbt_temp`|C|string|
 |DC PV1 voltage|0x6d|`dc/pv1/voltage`|V||
 |DC PV1 current|0x6e|`dc/pv1/current`|A||
 |DC PV1 power|computed|`dc/pv1/power`|W||

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Additional groups may be added in the future.
 |AC Phase 1 current|0x4c|`ac/l1/current`|A|string, micro|
 |AC Phase 2 current|0x4d|`ac/l2/current`|A|string|
 |AC Phase 3 current|0x4e|`ac/l3/current`|A|string|
+|AC Phase 1 power|computed|`ac/l1/power`|W|string, micro|
+|AC Phase 2 power|computed|`ac/l2/power`|W|string|
+|AC Phase 3 power|computed|`ac/l3/power`|W|string|
 |AC Frequency|0x4f|`ac/freq`|Hz||
 |Operating power|0x50|`operating_power`|W|string, micro|
 |DC total power|0x52|`dc/total_power`|W|string|

--- a/deye_mqtt_inttest.py
+++ b/deye_mqtt_inttest.py
@@ -23,7 +23,7 @@ from datetime import datetime
 import paho.mqtt.client as paho
 
 from deye_observation import Observation
-from deye_sensors import dc_power_sensor
+from deye_sensors import string_dc_power_sensor
 from deye_mqtt import DeyeMqttClient
 from deye_config import DeyeConfig, DeyeMqttConfig
 
@@ -62,10 +62,10 @@ class DeyeMqttClientIntegrationTest(unittest.TestCase):
 
         # and
         timestamp = datetime.now()
-        observation = Observation(dc_power_sensor, timestamp, 1.2)
+        observation = Observation(string_dc_power_sensor, timestamp, 1.2)
 
         # and
-        self.test_mqtt_client.subscribe(f'deye/{dc_power_sensor.mqtt_topic_suffix}')
+        self.test_mqtt_client.subscribe(f'deye/{string_dc_power_sensor.mqtt_topic_suffix}')
 
         # when
         self.test_mqtt_client.loop_start()

--- a/deye_sensor.py
+++ b/deye_sensor.py
@@ -99,7 +99,7 @@ class DoubleRegisterSensor(Sensor):
 
 class ComputedPowerSensor(Sensor):
     """
-    Electric Power sensor with value computed as multiplication of valures reag by voltage and current sensors.
+    Electric Power sensor with value computed as multiplication of values read by voltage and current sensors.
     """
 
     def __init__(
@@ -116,3 +116,23 @@ class ComputedPowerSensor(Sensor):
             return voltage * current
         else:
             return None
+
+class ComputedSumSensor(Sensor):
+    """
+    Computes a sum of values read by given list of sensors.
+    """
+
+    def __init__(
+            self, name: str, sensors: list[Sensor], mqtt_topic_suffix='',
+            print_format='{:0.1f}', groups=[]):
+        super().__init__(name, mqtt_topic_suffix, print_format, groups)
+        self.sensors = sensors
+
+    def read_value(self, registers: dict[int, int]):
+        result = 0
+        sensor_values = [s.read_value(registers) for s in self.sensors]
+        for value in sensor_values:
+            if value is None:
+                return None
+            result += value
+        return result

--- a/deye_sensor_test.py
+++ b/deye_sensor_test.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import patch
+from deye_sensor import Sensor, ComputedSumSensor
+
+class TestSensor(Sensor):
+
+    def __init__(self, name, value):
+        super().__init__(name)
+        self.value = value
+
+    def read_value(self, registers):
+        return self.value
+
+
+class DeyeSensorTest(unittest.TestCase):
+
+    def test_sum_sensor_returns_sum_when_all_inputs_are_given(self):
+        # given
+        test_sensor1 = TestSensor("ts1", 1.1)
+        test_sensor2 = TestSensor("ts2", 2.2)
+
+        # and
+        sut = ComputedSumSensor('sum', [test_sensor1, test_sensor2])
+
+        # when
+        result = sut.read_value([])
+
+        # then
+        self.assertAlmostEqual(result, 3.3)
+
+    def test_sum_sensor_returns_none_when_any_input_is_none(self):
+        # given
+        test_sensor1 = TestSensor("ts1", 1.1)
+        test_sensor2 = TestSensor("ts2", None)
+
+        # and
+        sut = ComputedSumSensor('sum', [test_sensor1, test_sensor2])
+
+        # when
+        result = sut.read_value([])
+
+        # then
+        self.assertIsNone(result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/deye_sensors.py
+++ b/deye_sensors.py
@@ -98,11 +98,11 @@ micro_dc_power_sensor = ComputedSumSensor(
     "DC Total Power", [pv1_power_sensor, pv2_power_sensor, pv3_power_sensor, pv4_power_sensor],
     mqtt_topic_suffix='dc/total_power', groups=['micro'])
 ac_apparent_power_sensor = SingleRegisterSensor(
-    "AC Apparent Power", 0x54, 0.1, mqtt_topic_suffix='ac/apparent_power', groups=['string', 'micro'])
+    "AC Apparent Power", 0x54, 0.1, mqtt_topic_suffix='ac/apparent_power', groups=['string'])
 ac_active_power_sensor = DoubleRegisterSensor(
     "AC Active Power", 0x56, 0.1, mqtt_topic_suffix='ac/active_power', groups=['string', 'micro'])
 ac_reactive_power_sensor = SingleRegisterSensor(
-    "AC Reactive Power", 0x58, 0.1, mqtt_topic_suffix='ac/reactive_power', groups=['string', 'micro'])
+    "AC Reactive Power", 0x58, 0.1, mqtt_topic_suffix='ac/reactive_power', groups=['string'])
 production_total_sensor = DoubleRegisterSensor(
     "Production Total", 0x3f, 0.1, mqtt_topic_suffix='total_energy', groups=['string', 'micro'])
 

--- a/deye_sensors.py
+++ b/deye_sensors.py
@@ -93,7 +93,7 @@ pv4_total_sensor = DoubleRegisterSensor(
 operating_power_sensor = SingleRegisterSensor(
     "Operating Power", 0x50, 0.1, mqtt_topic_suffix='operating_power', groups=['string', 'micro'])
 string_dc_power_sensor = SingleRegisterSensor(
-    "DC Total Power", 0x52, 0.1, mqtt_topic_suffix='dc/total_power', groups=['string', 'micro'])
+    "DC Total Power", 0x52, 0.1, mqtt_topic_suffix='dc/total_power', groups=['string'])
 micro_dc_power_sensor = ComputedSumSensor(
     "DC Total Power", [pv1_power_sensor, pv2_power_sensor, pv3_power_sensor, pv4_power_sensor],
     mqtt_topic_suffix='dc/total_power', groups=['micro'])

--- a/deye_sensors.py
+++ b/deye_sensors.py
@@ -15,15 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from deye_sensor import SingleRegisterSensor, ComputedPowerSensor, DoubleRegisterSensor
+from deye_sensor import SingleRegisterSensor, ComputedPowerSensor, DoubleRegisterSensor, ComputedSumSensor
 
 # AC Phase 1
 phase1_voltage_sensor = SingleRegisterSensor(
     "Phase1 Voltage", 0x49, 0.1, mqtt_topic_suffix='ac/l1/voltage', groups=['string', 'micro'])
 phase1_current_sensor = SingleRegisterSensor(
     "Phase1 Current", 0x4c, 0.1, mqtt_topic_suffix='ac/l1/current', groups=['string', 'micro'])
-phase1_power_sensor = ComputedPowerSensor("Phase1 Power", phase1_voltage_sensor,
-                                          phase1_current_sensor, mqtt_topic_suffix='ac/l1/power', groups=['string', 'micro'])
+phase1_power_sensor = ComputedPowerSensor(
+    "Phase1 Power", phase1_voltage_sensor, phase1_current_sensor, mqtt_topic_suffix='ac/l1/power',
+    groups=['string', 'micro'])
 
 # AC Phase 2
 phase2_voltage_sensor = SingleRegisterSensor(
@@ -53,40 +54,57 @@ pv1_voltage_sensor = SingleRegisterSensor("PV1 Voltage", 0x6d, 0.1, mqtt_topic_s
 pv1_current_sensor = SingleRegisterSensor("PV1 Current", 0x6e, 0.1, mqtt_topic_suffix='dc/pv1/current')
 pv1_power_sensor = ComputedPowerSensor("PV1 Power", pv1_voltage_sensor,
                                        pv1_current_sensor, mqtt_topic_suffix='dc/pv1/power')
-pv1_daily_sensor = SingleRegisterSensor("PV1 Production today", 0x41, 0.1, mqtt_topic_suffix='dc/pv1/day_energy', groups=['micro'])
-pv1_total_sensor = DoubleRegisterSensor("PV1 Total", 0x45, 0.1, mqtt_topic_suffix='dc/pv1/total_energy', groups=['micro'])
+pv1_daily_sensor = SingleRegisterSensor("PV1 Production today", 0x41, 0.1,
+                                        mqtt_topic_suffix='dc/pv1/day_energy', groups=['micro'])
+pv1_total_sensor = DoubleRegisterSensor(
+    "PV1 Total", 0x45, 0.1, mqtt_topic_suffix='dc/pv1/total_energy', groups=['micro'])
 
 # DC PV2
 pv2_voltage_sensor = SingleRegisterSensor("PV2 Voltage", 0x6f, 0.1, mqtt_topic_suffix='dc/pv2/voltage')
 pv2_current_sensor = SingleRegisterSensor("PV2 Current", 0x70, 0.1, mqtt_topic_suffix='dc/pv2/current')
 pv2_power_sensor = ComputedPowerSensor("PV2 Power", pv2_voltage_sensor,
                                        pv2_current_sensor, mqtt_topic_suffix='dc/pv2/power')
-pv2_daily_sensor = SingleRegisterSensor("PV2 Production today", 0x42, 0.1, mqtt_topic_suffix='dc/pv2/day_energy', groups=['micro'])
-pv2_total_sensor = DoubleRegisterSensor("PV2 Total", 0x47, 0.1, mqtt_topic_suffix='dc/pv2/total_energy', groups=['micro'])
+pv2_daily_sensor = SingleRegisterSensor("PV2 Production today", 0x42, 0.1,
+                                        mqtt_topic_suffix='dc/pv2/day_energy', groups=['micro'])
+pv2_total_sensor = DoubleRegisterSensor(
+    "PV2 Total", 0x47, 0.1, mqtt_topic_suffix='dc/pv2/total_energy', groups=['micro'])
 
 # DC PV3
 pv3_voltage_sensor = SingleRegisterSensor("PV3 Voltage", 0x71, 0.1, mqtt_topic_suffix='dc/pv3/voltage')
 pv3_current_sensor = SingleRegisterSensor("PV3 Current", 0x72, 0.1, mqtt_topic_suffix='dc/pv3/current')
 pv3_power_sensor = ComputedPowerSensor("PV3 Power", pv3_voltage_sensor,
                                        pv3_current_sensor, mqtt_topic_suffix='dc/pv3/power')
-pv3_daily_sensor = SingleRegisterSensor("PV3 Production today", 0x43, 0.1, mqtt_topic_suffix='dc/pv3/day_energy', groups=['micro'])
-pv3_total_sensor = DoubleRegisterSensor("PV3 Total", 0x4a, 0.1, mqtt_topic_suffix='dc/pv3/total_energy', groups=['micro'])
+pv3_daily_sensor = SingleRegisterSensor("PV3 Production today", 0x43, 0.1,
+                                        mqtt_topic_suffix='dc/pv3/day_energy', groups=['micro'])
+pv3_total_sensor = DoubleRegisterSensor(
+    "PV3 Total", 0x4a, 0.1, mqtt_topic_suffix='dc/pv3/total_energy', groups=['micro'])
 
 # DC PV4
 pv4_voltage_sensor = SingleRegisterSensor("PV4 Voltage", 0x73, 0.1, mqtt_topic_suffix='dc/pv4/voltage')
 pv4_current_sensor = SingleRegisterSensor("PV4 Current", 0x74, 0.1, mqtt_topic_suffix='dc/pv4/current')
 pv4_power_sensor = ComputedPowerSensor("PV4 Power", pv4_voltage_sensor,
                                        pv4_current_sensor, mqtt_topic_suffix='dc/pv4/power')
-pv4_daily_sensor = SingleRegisterSensor("PV4 Production today", 0x44, 0.1, mqtt_topic_suffix='dc/pv4/day_energy', groups=['micro'])
-pv4_total_sensor = DoubleRegisterSensor("PV4 Total", 0x4d, 0.1, mqtt_topic_suffix='dc/pv4/total_energy', groups=['micro'])
+pv4_daily_sensor = SingleRegisterSensor("PV4 Production today", 0x44, 0.1,
+                                        mqtt_topic_suffix='dc/pv4/day_energy', groups=['micro'])
+pv4_total_sensor = DoubleRegisterSensor(
+    "PV4 Total", 0x4d, 0.1, mqtt_topic_suffix='dc/pv4/total_energy', groups=['micro'])
 
 # Power sensors
-operating_power_sensor = SingleRegisterSensor("Operating Power", 0x50, 0.1, mqtt_topic_suffix='operating_power', groups=['string', 'micro'])
-dc_power_sensor = SingleRegisterSensor("DC Total Power", 0x52, 0.1, mqtt_topic_suffix='dc/total_power', groups=['string', 'micro'])
-ac_apparent_power_sensor = SingleRegisterSensor("AC Apparent Power", 0x54, 0.1, mqtt_topic_suffix='ac/apparent_power', groups=['string', 'micro'])
-ac_active_power_sensor = DoubleRegisterSensor("AC Active Power", 0x56, 0.1, mqtt_topic_suffix='ac/active_power', groups=['string', 'micro'])
-ac_reactive_power_sensor = SingleRegisterSensor("AC Reactive Power", 0x58, 0.1, mqtt_topic_suffix='ac/reactive_power', groups=['string', 'micro'])
-production_total_sensor = DoubleRegisterSensor("Production Total", 0x3f, 0.1, mqtt_topic_suffix='total_energy', groups=['string', 'micro'])
+operating_power_sensor = SingleRegisterSensor(
+    "Operating Power", 0x50, 0.1, mqtt_topic_suffix='operating_power', groups=['string', 'micro'])
+string_dc_power_sensor = SingleRegisterSensor(
+    "DC Total Power", 0x52, 0.1, mqtt_topic_suffix='dc/total_power', groups=['string', 'micro'])
+micro_dc_power_sensor = ComputedSumSensor(
+    "DC Total Power", [pv1_power_sensor, pv2_power_sensor, pv3_power_sensor, pv4_power_sensor],
+    mqtt_topic_suffix='dc/total_power', groups=['micro'])
+ac_apparent_power_sensor = SingleRegisterSensor(
+    "AC Apparent Power", 0x54, 0.1, mqtt_topic_suffix='ac/apparent_power', groups=['string', 'micro'])
+ac_active_power_sensor = DoubleRegisterSensor(
+    "AC Active Power", 0x56, 0.1, mqtt_topic_suffix='ac/active_power', groups=['string', 'micro'])
+ac_reactive_power_sensor = SingleRegisterSensor(
+    "AC Reactive Power", 0x58, 0.1, mqtt_topic_suffix='ac/reactive_power', groups=['string', 'micro'])
+production_total_sensor = DoubleRegisterSensor(
+    "Production Total", 0x3f, 0.1, mqtt_topic_suffix='total_energy', groups=['string', 'micro'])
 
 # Temperature sensors
 radiator_temp_sensor = SingleRegisterSensor("Radiator temperature", 0x5a, 0.1,
@@ -127,7 +145,7 @@ sensor_list = [
     pv4_power_sensor,
     pv4_daily_sensor,
     pv4_total_sensor,
-    dc_power_sensor,
+    string_dc_power_sensor,
     operating_power_sensor,
     ac_apparent_power_sensor,
     ac_active_power_sensor,

--- a/deye_sensors.py
+++ b/deye_sensors.py
@@ -147,6 +147,7 @@ sensor_list = [
     pv4_daily_sensor,
     pv4_total_sensor,
     string_dc_power_sensor,
+    micro_dc_power_sensor,
     operating_power_sensor,
     ac_apparent_power_sensor,
     ac_active_power_sensor,

--- a/deye_sensors.py
+++ b/deye_sensors.py
@@ -109,7 +109,8 @@ production_total_sensor = DoubleRegisterSensor(
 # Temperature sensors
 radiator_temp_sensor = SingleRegisterSensor("Radiator temperature", 0x5a, 0.1,
                                             offset=-100, mqtt_topic_suffix='radiator_temp')
-igbt_temp_sensor = SingleRegisterSensor("IGBT temperature", 0x5b, 0.1, offset=-100, mqtt_topic_suffix='igbt_temp')
+igbt_temp_sensor = SingleRegisterSensor("IGBT temperature", 0x5b, 0.1, offset=-100,
+                                        mqtt_topic_suffix='igbt_temp', groups=['string'])
 
 sensor_list = [
     production_today_sensor,


### PR DESCRIPTION
Micro inverters do not report DC Total Power. Mitigate this by computing it as a sum of PV1,PV2,PV3,PV4 power metrics.