### PR TITLE
Fix error reported when writing modbus register

### DIFF
--- a/deye_modbus.py
+++ b/deye_modbus.py
@@ -123,7 +123,7 @@ class DeyeModbus:
         if not frame:
             self.__log.error("Modbus response frame is empty")
             return False
-        elif len(frame) != expected_frame_len:
+        elif len(frame) < expected_frame_len:
             self.__log.error(
                 f"Wrong response frame length. Expected at least {expected_frame_len} bytes, got {len(frame)}")
             return False


### PR DESCRIPTION
The logger has started sending two additional zero bytes at the end of the modbus write registers response frame.
This change will ignore that additional bytes.