### PR TITLE
IGEN DTSD422-D3 Smartmeter support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ docker-push-beta: test
 		.
 	@docker buildx rm --all-inactive --force
 
-METRIC_GROUPS = string micro deye_sg04lp3 deye_sg04lp3_battery
+METRIC_GROUPS = string micro deye_sg04lp3 deye_sg04lp3_battery igen_dtsd422
 GENERATE_DOCS_TARGETS = $(addprefix generate-docs-, $(METRIC_GROUPS))
 $(GENERATE_DOCS_TARGETS): generate-docs-%:
 	@mkdir -p docs

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ When your inverter turns out to work well with an already exiting metrics group,
 | [Deye SUN1300-2000G3-US-220/EU-230](https://www.deyeinverter.com/product/microinverter-1/sun13002000g3eu230.html)                                                         | [micro](docs/metric_group_micro.md)                                                                                  |
 | [Deye SUN-5/6/8/10/12K-SG04LP3](https://deye.com/product/sun-5-6-8-10-12k-sg04lp3-5-12kw-three-phase-2-mppt-hybrid-inverter-low-voltage-battery/)                         | [deye_sg04lp3](docs/metric_group_deye_sg04lp3.md), [deye_sg04lp3_battery](docs/metric_group_deye_sg04lp3_battery.md) |
 
+| Meter model                                                         | Metric groups                                     |
+| ------------------------------------------------------------------- | ------------------------------------------------- |
+| [IGEN DTSD422-D3](https://www.solarmanpv.com/products/smart-meter/) | [igen_dtsd422](docs/metric_group_igen_dtsd422.md) |
+
 Rebranded models
 | Inverter model                                                                                                                 | Metric groups                         |
 | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
@@ -125,6 +129,7 @@ All configuration options are controlled through environment variables.
     * `micro` - micro inverter
     * `deye_sg04lp3` - sg04lp3 inverter
     * `deye_sg04lp3_battery` - sg04lp3 battery
+    * ìgen_dtsd422`- stsd422 smart meter
 * `DEYE_LOGGER_SERIAL_NUMBER` - inverter data logger serial number
 * `DEYE_LOGGER_IP_ADDRESS` - inverter data logger IP address
 * `DEYE_LOGGER_PORT` - inverter data logger communication port, typically 8899

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ All configuration options are controlled through environment variables.
     * `micro` - micro inverter
     * `deye_sg04lp3` - sg04lp3 inverter
     * `deye_sg04lp3_battery` - sg04lp3 battery
-    * `igen_dtsd422`- stsd422 smart meter
+    * `igen_dtsd422`- dtsd422 smart meter
 * `DEYE_LOGGER_SERIAL_NUMBER` - inverter data logger serial number
 * `DEYE_LOGGER_IP_ADDRESS` - inverter data logger IP address
 * `DEYE_LOGGER_PORT` - inverter data logger communication port, typically 8899

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ All configuration options are controlled through environment variables.
     * `micro` - micro inverter
     * `deye_sg04lp3` - sg04lp3 inverter
     * `deye_sg04lp3_battery` - sg04lp3 battery
-    * ìgen_dtsd422`- stsd422 smart meter
+    * `igen_dtsd422`- stsd422 smart meter
 * `DEYE_LOGGER_SERIAL_NUMBER` - inverter data logger serial number
 * `DEYE_LOGGER_IP_ADDRESS` - inverter data logger IP address
 * `DEYE_LOGGER_PORT` - inverter data logger communication port, typically 8899

--- a/deye_sensor.py
+++ b/deye_sensor.py
@@ -116,8 +116,8 @@ class DoubleRegisterSensor(Sensor):
 
 class SignedMagnitudeSingleRegisterSensor(SingleRegisterSensor):
     """
-    Power meter sensor with value stored as 10-bit integer in a single Modbus register and the first byte
-    indicating power direction.
+    Reads single Modbus register as signed, fixed point 15-bits long value.
+    The most significant bit encodes the sign.
     """
 
     def read_value(self, registers: dict[int, bytearray]):
@@ -137,9 +137,8 @@ class SignedMagnitudeSingleRegisterSensor(SingleRegisterSensor):
 
 class SignedMagnitudeDoubleRegisterSensor(DoubleRegisterSensor):
     """
-    Power meter sensor with value stored as 32-bit integer in two Modbus registers and the energy flow direction
-    stored in the first Modbus register. High and Low words are swapped compared to the normal DoubleRegisterSensor.
-    Highest bit gives energy direction.
+    Reads double Modbus registers as signed, fixed point 31-bits long value.
+    The most significant bit encodes the sign.
     """
 
     def read_value(self, registers: dict[int, bytearray]):

--- a/deye_sensor.py
+++ b/deye_sensor.py
@@ -114,6 +114,52 @@ class DoubleRegisterSensor(Sensor):
         return [self.reg_address, self.reg_address+1]
 
 
+class SignedMagnitudeSingleRegisterSensor(SingleRegisterSensor):
+    """
+    Power meter sensor with value stored as 10-bit integer in a single Modbus register and the first byte
+    indicating power direction.
+    """
+
+    def read_value(self, registers: dict[int, bytearray]):
+        if self.reg_address in registers:
+            reg_value = (
+                int.from_bytes(registers[self.reg_address], "big", signed=False)
+                & 0x7FFF
+            )
+            # If highest bit is set, we've got a negative value
+            if bool(registers[self.reg_address][0] & 0x80):
+                return -1 * reg_value * self.factor + self.offset
+            else:
+                return reg_value * self.factor + self.offset
+        else:
+            return None
+
+
+class SignedMagnitudeDoubleRegisterSensor(DoubleRegisterSensor):
+    """
+    Power meter sensor with value stored as 32-bit integer in two Modbus registers and the energy flow direction
+    stored in the first Modbus register. High and Low words are swapped compared to the normal DoubleRegisterSensor.
+    Highest bit gives energy direction.
+    """
+
+    def read_value(self, registers: dict[int, bytearray]):
+        high_word_reg_address = self.reg_address
+        low_word_reg_address = self.reg_address + 1
+        if low_word_reg_address in registers and high_word_reg_address in registers:
+            low_word = registers[low_word_reg_address]
+            high_word = registers[high_word_reg_address]
+            reg_value = (
+                int.from_bytes(high_word + low_word, "big", signed=False) & 0x7FFFFFFF
+            )
+            # If highest bit is set, we've got a negative value
+            if bool(registers[self.reg_address][0] & 0x80):
+                return -1 * reg_value * self.factor + self.offset
+            else:
+                return reg_value * self.factor + self.offset
+        else:
+            return None
+
+
 class ComputedPowerSensor(Sensor):
     """
     Electric Power sensor with value computed as multiplication of values read by voltage and current sensors.

--- a/deye_sensor_test.py
+++ b/deye_sensor_test.py
@@ -17,7 +17,14 @@
 
 import unittest
 from unittest.mock import patch
-from deye_sensor import Sensor, ComputedSumSensor, DoubleRegisterSensor, SingleRegisterSensor
+from deye_sensor import (
+    Sensor,
+    ComputedSumSensor,
+    DoubleRegisterSensor,
+    SingleRegisterSensor,
+    SignedMagnitudeSingleRegisterSensor,
+    SignedMagnitudeDoubleRegisterSensor,
+)
 
 
 class TestSensor(Sensor):
@@ -75,7 +82,7 @@ class DeyeSensorTest(unittest.TestCase):
         # then
         self.assertEqual(result, 0x0102)
 
-    def test_dobule_reg_sensor_signed(self):
+    def test_double_reg_sensor_signed(self):
         # given
         sut = SingleRegisterSensor('test', 0x00, 1, signed=True, groups=['string'])
 
@@ -90,7 +97,7 @@ class DeyeSensorTest(unittest.TestCase):
         # then
         self.assertEqual(result, -2)
 
-    def test_dobule_reg_sensor_unsigned(self):
+    def test_double_reg_sensor_unsigned(self):
         # given
         sut = DoubleRegisterSensor('test', 0x00, 1, signed=False, groups=['string'])
 
@@ -106,7 +113,7 @@ class DeyeSensorTest(unittest.TestCase):
         # then
         self.assertEqual(result, 0x03040102)
 
-    def test_dobule_reg_sensor_signed(self):
+    def test_double_reg_sensor_signed(self):
         # given
         sut = DoubleRegisterSensor('test', 0x00, 1, signed=True, groups=['string'])
 
@@ -121,6 +128,68 @@ class DeyeSensorTest(unittest.TestCase):
 
         # then
         self.assertEqual(result, -2)
+
+    def test_signed_magnitude_single_register_signed(self):
+        # given
+        sut = SignedMagnitudeSingleRegisterSensor('test', 0x00, 1, groups=['igen_dtsd422'])
+
+        # and
+        registers = {
+            0: bytearray.fromhex('8310')
+        }
+
+        # when
+        result = sut.read_value(registers)
+
+        # then
+        self.assertEqual(result, -784)
+
+    def test_signed_magnitude_single_register_unsigned(self):
+        # given
+        sut = SignedMagnitudeSingleRegisterSensor('test', 0x00, 1, groups=['igen_dtsd422'])
+
+        # and
+        registers = {
+            0: bytearray.fromhex('0310')
+        }
+
+        # when
+        result = sut.read_value(registers)
+
+        # then
+        self.assertEqual(result, 784)
+
+    def test_signed_magnitude_double_register_signed(self):
+        # given
+        sut = SignedMagnitudeDoubleRegisterSensor('test', 0x00, 1, groups=['igen_dtsd422'])
+
+        # and
+        registers = {
+            0: bytearray.fromhex('8000'),  # high word
+            1: bytearray.fromhex('0101')  # low word
+        }
+
+        # when
+        result = sut.read_value(registers)
+
+        # then
+        self.assertEqual(result, -257)
+
+    def test_signed_magnitude_double_register_unsigned(self):
+        # given
+        sut = SignedMagnitudeDoubleRegisterSensor('test', 0x00, 1, groups=['igen_dtsd422'])
+
+        # and
+        registers = {
+            0: bytearray.fromhex('0000'),  # high word
+            1: bytearray.fromhex('0101')  # low word
+        }
+
+        # when
+        result = sut.read_value(registers)
+
+        # then
+        self.assertEqual(result, 257)
 
 
 if __name__ == '__main__':

--- a/deye_sensors.py
+++ b/deye_sensors.py
@@ -18,6 +18,7 @@
 from deye_sensor import SingleRegisterSensor, ComputedPowerSensor, DoubleRegisterSensor, ComputedSumSensor, SensorRegisterRange
 
 from deye_sensors_deye_sg04lp3 import deye_sg04lp3_sensors, deye_sg04lp3_register_ranges
+from deye_sensors_igen_dtsd422 import igen_dtsd422_sensors, igen_dtsd422_register_ranges
 
 # AC Phase 1
 phase1_voltage_sensor = SingleRegisterSensor(
@@ -176,9 +177,9 @@ sensor_list = [
     string_radiator_temp_sensor,
     micro_radiator_temp_sensor,
     igbt_temp_sensor
-] + deye_sg04lp3_sensors
+] + deye_sg04lp3_sensors + igen_dtsd422_sensors
 
 sensor_register_ranges = [
     SensorRegisterRange(group='string', first_reg_address=0x3c, last_reg_address=0x74),
     SensorRegisterRange(group='micro', first_reg_address=0x3c, last_reg_address=0x74)
-] + deye_sg04lp3_register_ranges
+] + deye_sg04lp3_register_ranges + igen_dtsd422_register_ranges

--- a/deye_sensors_igen_dtsd422.py
+++ b/deye_sensors_igen_dtsd422.py
@@ -17,31 +17,29 @@
 
 from deye_sensor import (
     SingleRegisterSensor,
-    ComputedPowerSensor,
     DoubleRegisterSensor,
-    ComputedSumSensor,
+    SignedMagnitudeSingleRegisterSensor,
+    SignedMagnitudeDoubleRegisterSensor,
     SensorRegisterRange,
 )
 
 #
-# Initial IGEN DTSD-422-D3 support.
+# IGEN DTSD-422-D3 support.
 #
 # Todo:
 # * Daily Values for Positive and Negative energy are missing, can't find them.
 # * Need to verify data is still read correctly when double reg values exceed one
 #   register
-# * There are some more informational registers, e.g. Manufacturing Date, serial etc. which
-#   we're ignoring for now. Maybe add?
 #
 
 
-class SingleDirectionRegisterSensor(SingleRegisterSensor):
+class SignedMagnitudeSingleRegisterSensor(SingleRegisterSensor):
     """
     Power meter sensor with value stored as 10-bit integer in a single Modbus register and the first byte
     indicating power direction.
     """
 
-    def read_value(self, registers: dict[int, int]):
+    def read_value(self, registers: dict[int, bytearray]):
         if self.reg_address in registers:
             reg_value = (
                 int.from_bytes(registers[self.reg_address], "big", signed=False)
@@ -56,14 +54,14 @@ class SingleDirectionRegisterSensor(SingleRegisterSensor):
             return None
 
 
-class DoubleDirectionRegisterSensor(DoubleRegisterSensor):
+class SignedMagnitudeDoubleRegisterSensor(DoubleRegisterSensor):
     """
     Power meter sensor with value stored as 32-bit integer in two Modbus registers and the energy flow direction
     stored in the first Modbus register. High and Low words are swapped compared to the normal DoubleRegisterSensor.
     Highest bit gives energy direction.
     """
 
-    def read_value(self, registers: dict[int, int]):
+    def read_value(self, registers: dict[int, bytearray]):
         high_word_reg_address = self.reg_address
         low_word_reg_address = self.reg_address + 1
         if low_word_reg_address in registers and high_word_reg_address in registers:

--- a/deye_sensors_igen_dtsd422.py
+++ b/deye_sensors_igen_dtsd422.py
@@ -32,53 +32,6 @@ from deye_sensor import (
 #   register
 #
 
-
-class SignedMagnitudeSingleRegisterSensor(SingleRegisterSensor):
-    """
-    Power meter sensor with value stored as 10-bit integer in a single Modbus register and the first byte
-    indicating power direction.
-    """
-
-    def read_value(self, registers: dict[int, bytearray]):
-        if self.reg_address in registers:
-            reg_value = (
-                int.from_bytes(registers[self.reg_address], "big", signed=False)
-                & 0x7FFF
-            )
-            # If highest bit is set, we've got a negative value
-            if bool(registers[self.reg_address][0] & 0x80):
-                return -1 * reg_value * self.factor + self.offset
-            else:
-                return reg_value * self.factor + self.offset
-        else:
-            return None
-
-
-class SignedMagnitudeDoubleRegisterSensor(DoubleRegisterSensor):
-    """
-    Power meter sensor with value stored as 32-bit integer in two Modbus registers and the energy flow direction
-    stored in the first Modbus register. High and Low words are swapped compared to the normal DoubleRegisterSensor.
-    Highest bit gives energy direction.
-    """
-
-    def read_value(self, registers: dict[int, bytearray]):
-        high_word_reg_address = self.reg_address
-        low_word_reg_address = self.reg_address + 1
-        if low_word_reg_address in registers and high_word_reg_address in registers:
-            low_word = registers[low_word_reg_address]
-            high_word = registers[high_word_reg_address]
-            reg_value = (
-                int.from_bytes(high_word + low_word, "big", signed=False) & 0x7FFFFFFF
-            )
-            # If highest bit is set, we've got a negative value
-            if bool(registers[self.reg_address][0] & 0x80):
-                return -1 * reg_value * self.factor + self.offset
-            else:
-                return reg_value * self.factor + self.offset
-        else:
-            return None
-
-
 # CT1
 ct1_voltage_sensor = SingleRegisterSensor(
     "Voltage CT1",

--- a/deye_sensors_igen_dtsd422.py
+++ b/deye_sensors_igen_dtsd422.py
@@ -41,7 +41,7 @@ ct1_voltage_sensor = SingleRegisterSensor(
     unit="V",
     groups=["igen_dtsd422"],
 )
-ct1_current_sensor = DoubleDirectionRegisterSensor(
+ct1_current_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Current CT1",
     0x07,
     0.001,
@@ -50,7 +50,7 @@ ct1_current_sensor = DoubleDirectionRegisterSensor(
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
-ct1_active_power_sensor = DoubleDirectionRegisterSensor(
+ct1_active_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Active Power CT1",
     0x0F,
     1,
@@ -58,7 +58,7 @@ ct1_active_power_sensor = DoubleDirectionRegisterSensor(
     unit="W",
     groups=["igen_dtsd422"],
 )
-ct1_reactive_power_sensor = DoubleDirectionRegisterSensor(
+ct1_reactive_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Reactive Power CT1",
     0x17,
     1,
@@ -66,7 +66,7 @@ ct1_reactive_power_sensor = DoubleDirectionRegisterSensor(
     unit="Var",
     groups=["igen_dtsd422"],
 )
-ct1_apparent_power_sensor = DoubleDirectionRegisterSensor(
+ct1_apparent_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Apparent Power CT1",
     0x1F,
     1,
@@ -74,7 +74,7 @@ ct1_apparent_power_sensor = DoubleDirectionRegisterSensor(
     unit="VA",
     groups=["igen_dtsd422"],
 )
-ct1_power_factor_sensor = SingleDirectionRegisterSensor(
+ct1_power_factor_sensor = SignedMagnitudeSingleRegisterSensor(
     "Power Factor CT1",
     0x26,
     0.001,
@@ -109,7 +109,7 @@ ct2_voltage_sensor = SingleRegisterSensor(
     unit="V",
     groups=["igen_dtsd422"],
 )
-ct2_current_sensor = DoubleDirectionRegisterSensor(
+ct2_current_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Current CT2",
     0x09,
     0.001,
@@ -118,7 +118,7 @@ ct2_current_sensor = DoubleDirectionRegisterSensor(
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
-ct2_active_power_sensor = DoubleDirectionRegisterSensor(
+ct2_active_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Active Power CT2",
     0x11,
     1,
@@ -126,7 +126,7 @@ ct2_active_power_sensor = DoubleDirectionRegisterSensor(
     unit="W",
     groups=["igen_dtsd422"],
 )
-ct2_reactive_power_sensor = DoubleDirectionRegisterSensor(
+ct2_reactive_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Reactive Power CT2",
     0x19,
     1,
@@ -134,7 +134,7 @@ ct2_reactive_power_sensor = DoubleDirectionRegisterSensor(
     unit="Var",
     groups=["igen_dtsd422"],
 )
-ct2_apparent_power_sensor = DoubleDirectionRegisterSensor(
+ct2_apparent_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Apparent Power CT2",
     0x21,
     1,
@@ -142,7 +142,7 @@ ct2_apparent_power_sensor = DoubleDirectionRegisterSensor(
     unit="VA",
     groups=["igen_dtsd422"],
 )
-ct2_power_factor_sensor = SingleDirectionRegisterSensor(
+ct2_power_factor_sensor = SignedMagnitudeSingleRegisterSensor(
     "Power Factor CT2",
     0x27,
     0.001,
@@ -177,7 +177,7 @@ ct3_voltage_sensor = SingleRegisterSensor(
     unit="V",
     groups=["igen_dtsd422"],
 )
-ct3_current_sensor = DoubleDirectionRegisterSensor(
+ct3_current_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Current CT3",
     0x0B,
     0.001,
@@ -186,7 +186,7 @@ ct3_current_sensor = DoubleDirectionRegisterSensor(
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
-ct3_active_power_sensor = DoubleDirectionRegisterSensor(
+ct3_active_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Active Power CT3",
     0x13,
     1,
@@ -194,7 +194,7 @@ ct3_active_power_sensor = DoubleDirectionRegisterSensor(
     unit="W",
     groups=["igen_dtsd422"],
 )
-ct3_reactive_power_sensor = DoubleDirectionRegisterSensor(
+ct3_reactive_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Reactive Power CT3",
     0x1B,
     1,
@@ -202,7 +202,7 @@ ct3_reactive_power_sensor = DoubleDirectionRegisterSensor(
     unit="Var",
     groups=["igen_dtsd422"],
 )
-ct3_apparent_power_sensor = DoubleDirectionRegisterSensor(
+ct3_apparent_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Apparent Power CT3",
     0x23,
     1,
@@ -210,7 +210,7 @@ ct3_apparent_power_sensor = DoubleDirectionRegisterSensor(
     unit="VA",
     groups=["igen_dtsd422"],
 )
-ct3_power_factor_sensor = SingleDirectionRegisterSensor(
+ct3_power_factor_sensor = SignedMagnitudeSingleRegisterSensor(
     "Power Factor CT3",
     0x28,
     0.001,
@@ -245,7 +245,7 @@ ct4_voltage_sensor = SingleRegisterSensor(
     unit="V",
     groups=["igen_dtsd422"],
 )
-ct4_current_sensor = DoubleDirectionRegisterSensor(
+ct4_current_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Current CT4",
     0x1007,
     0.001,
@@ -254,7 +254,7 @@ ct4_current_sensor = DoubleDirectionRegisterSensor(
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
-ct4_active_power_sensor = DoubleDirectionRegisterSensor(
+ct4_active_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Active Power CT4",
     0x100F,
     1,
@@ -262,7 +262,7 @@ ct4_active_power_sensor = DoubleDirectionRegisterSensor(
     unit="W",
     groups=["igen_dtsd422"],
 )
-ct4_reactive_power_sensor = DoubleDirectionRegisterSensor(
+ct4_reactive_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Reactive Power CT4",
     0x1017,
     1,
@@ -270,7 +270,7 @@ ct4_reactive_power_sensor = DoubleDirectionRegisterSensor(
     unit="Var",
     groups=["igen_dtsd422"],
 )
-ct4_apparent_power_sensor = DoubleDirectionRegisterSensor(
+ct4_apparent_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Apparent Power CT4",
     0x101F,
     1,
@@ -278,7 +278,7 @@ ct4_apparent_power_sensor = DoubleDirectionRegisterSensor(
     unit="VA",
     groups=["igen_dtsd422"],
 )
-ct4_power_factor_sensor = SingleDirectionRegisterSensor(
+ct4_power_factor_sensor = SignedMagnitudeSingleRegisterSensor(
     "Power Factor CT4",
     0x1026,
     0.001,
@@ -313,7 +313,7 @@ ct5_voltage_sensor = SingleRegisterSensor(
     unit="V",
     groups=["igen_dtsd422"],
 )
-ct5_current_sensor = DoubleDirectionRegisterSensor(
+ct5_current_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Current CT5",
     0x1009,
     0.001,
@@ -322,7 +322,7 @@ ct5_current_sensor = DoubleDirectionRegisterSensor(
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
-ct5_active_power_sensor = DoubleDirectionRegisterSensor(
+ct5_active_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Active Power CT5",
     0x1011,
     1,
@@ -330,7 +330,7 @@ ct5_active_power_sensor = DoubleDirectionRegisterSensor(
     unit="W",
     groups=["igen_dtsd422"],
 )
-ct5_reactive_power_sensor = DoubleDirectionRegisterSensor(
+ct5_reactive_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Reactive Power CT5",
     0x1019,
     1,
@@ -338,7 +338,7 @@ ct5_reactive_power_sensor = DoubleDirectionRegisterSensor(
     unit="Var",
     groups=["igen_dtsd422"],
 )
-ct5_apparent_power_sensor = DoubleDirectionRegisterSensor(
+ct5_apparent_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Apparent Power CT5",
     0x1021,
     1,
@@ -346,7 +346,7 @@ ct5_apparent_power_sensor = DoubleDirectionRegisterSensor(
     unit="VA",
     groups=["igen_dtsd422"],
 )
-ct5_power_factor_sensor = SingleDirectionRegisterSensor(
+ct5_power_factor_sensor = SignedMagnitudeSingleRegisterSensor(
     "Power Factor CT5",
     0x1027,
     0.001,
@@ -381,7 +381,7 @@ ct6_voltage_sensor = SingleRegisterSensor(
     unit="V",
     groups=["igen_dtsd422"],
 )
-ct6_current_sensor = DoubleDirectionRegisterSensor(
+ct6_current_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Current CT6",
     0x100B,
     0.001,
@@ -390,7 +390,7 @@ ct6_current_sensor = DoubleDirectionRegisterSensor(
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
-ct6_active_power_sensor = DoubleDirectionRegisterSensor(
+ct6_active_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Active Power CT6",
     0x1013,
     1,
@@ -398,7 +398,7 @@ ct6_active_power_sensor = DoubleDirectionRegisterSensor(
     unit="W",
     groups=["igen_dtsd422"],
 )
-ct6_reactive_power_sensor = DoubleDirectionRegisterSensor(
+ct6_reactive_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Reactive Power CT6",
     0x101B,
     1,
@@ -406,7 +406,7 @@ ct6_reactive_power_sensor = DoubleDirectionRegisterSensor(
     unit="Var",
     groups=["igen_dtsd422"],
 )
-ct6_apparent_power_sensor = DoubleDirectionRegisterSensor(
+ct6_apparent_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Apparent Power CT6",
     0x1023,
     1,
@@ -414,7 +414,7 @@ ct6_apparent_power_sensor = DoubleDirectionRegisterSensor(
     unit="VA",
     groups=["igen_dtsd422"],
 )
-ct6_power_factor_sensor = SingleDirectionRegisterSensor(
+ct6_power_factor_sensor = SignedMagnitudeSingleRegisterSensor(
     "Power Factor CT6",
     0x1028,
     0.001,
@@ -441,7 +441,7 @@ ct6_total_negative_energy = SingleRegisterSensor(
 )
 
 # Total
-total_active_power_sensor = DoubleDirectionRegisterSensor(
+total_active_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Total Active Power",
     0x0D,
     1,
@@ -449,7 +449,7 @@ total_active_power_sensor = DoubleDirectionRegisterSensor(
     unit="W",
     groups=["igen_dtsd422"],
 )
-total_active_power2_sensor = DoubleDirectionRegisterSensor(
+total_active_power2_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Total Active Power 2",
     0x100D,
     1,
@@ -457,7 +457,7 @@ total_active_power2_sensor = DoubleDirectionRegisterSensor(
     unit="W",
     groups=["igen_dtsd422"],
 )
-total_reactive_power_sensor = DoubleDirectionRegisterSensor(
+total_reactive_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Total Reactive Power",
     0x15,
     1,
@@ -465,7 +465,7 @@ total_reactive_power_sensor = DoubleDirectionRegisterSensor(
     unit="Var",
     groups=["igen_dtsd422"],
 )
-total_reactive_power2_sensor = DoubleDirectionRegisterSensor(
+total_reactive_power2_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Total Reactive Power 2",
     0x1015,
     1,
@@ -473,7 +473,7 @@ total_reactive_power2_sensor = DoubleDirectionRegisterSensor(
     unit="Var",
     groups=["igen_dtsd422"],
 )
-total_apparent_power_sensor = DoubleDirectionRegisterSensor(
+total_apparent_power_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Total Apparent Power",
     0x1D,
     1,
@@ -481,7 +481,7 @@ total_apparent_power_sensor = DoubleDirectionRegisterSensor(
     unit="VA",
     groups=["igen_dtsd422"],
 )
-total_apparent_power2_sensor = DoubleDirectionRegisterSensor(
+total_apparent_power2_sensor = SignedMagnitudeDoubleRegisterSensor(
     "Total Apparent Power 2",
     0x101D,
     1,
@@ -523,14 +523,14 @@ total_negative_energy2_sensor = SingleRegisterSensor(
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
-total_power_factor_sensor = SingleDirectionRegisterSensor(
+total_power_factor_sensor = SignedMagnitudeSingleRegisterSensor(
     "Power Factor",
     0x25,
     0.001,
     mqtt_topic_suffix="total/power_factor",
     groups=["igen_dtsd422"],
 )
-total_power_factor2_sensor = SingleDirectionRegisterSensor(
+total_power_factor2_sensor = SignedMagnitudeSingleRegisterSensor(
     "Power Factor 2",
     0x1025,
     0.001,

--- a/deye_sensors_igen_dtsd422.py
+++ b/deye_sensors_igen_dtsd422.py
@@ -151,6 +151,7 @@ ct1_total_positive_energy = SingleRegisterSensor(
     0x3F,
     0.01,
     mqtt_topic_suffix="ct1/total_positive_energy",
+    unit="kWh",
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
@@ -159,6 +160,7 @@ ct1_total_negative_energy = SingleRegisterSensor(
     0x49,
     0.01,
     mqtt_topic_suffix="ct1/total_negative_energy",
+    unit="kWh",
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
@@ -217,6 +219,7 @@ ct2_total_positive_energy = SingleRegisterSensor(
     0x53,
     0.01,
     mqtt_topic_suffix="ct2/total_positive_energy",
+    unit="kWh",
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
@@ -225,6 +228,7 @@ ct2_total_negative_energy = SingleRegisterSensor(
     0x5D,
     0.01,
     mqtt_topic_suffix="ct2/total_negative_energy",
+    unit="kWh",
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
@@ -283,6 +287,7 @@ ct3_total_positive_energy = SingleRegisterSensor(
     0x67,
     0.01,
     mqtt_topic_suffix="ct3/total_positive_energy",
+    unit="kWh",
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
@@ -291,6 +296,7 @@ ct3_total_negative_energy = SingleRegisterSensor(
     0x71,
     0.01,
     mqtt_topic_suffix="ct3/total_negative_energy",
+    unit="kWh",
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
@@ -349,6 +355,7 @@ ct4_total_positive_energy = SingleRegisterSensor(
     0x103F,
     0.01,
     mqtt_topic_suffix="ct4/total_positive_energy",
+    unit="kWh",
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
@@ -357,6 +364,7 @@ ct4_total_negative_energy = SingleRegisterSensor(
     0x1049,
     0.01,
     mqtt_topic_suffix="ct4/total_negative_energy",
+    unit="kWh",
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
@@ -415,6 +423,7 @@ ct5_total_positive_energy = SingleRegisterSensor(
     0x1053,
     0.01,
     mqtt_topic_suffix="ct5/total_positive_energy",
+    unit="kWh",
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
@@ -423,6 +432,7 @@ ct5_total_negative_energy = SingleRegisterSensor(
     0x105D,
     0.01,
     mqtt_topic_suffix="ct5/total_negative_energy",
+    unit="kWh",
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
@@ -481,6 +491,7 @@ ct6_total_positive_energy = SingleRegisterSensor(
     0x1067,
     0.01,
     mqtt_topic_suffix="ct6/total_positive_energy",
+    unit="kWh",
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )
@@ -489,6 +500,7 @@ ct6_total_negative_energy = SingleRegisterSensor(
     0x1071,
     0.01,
     mqtt_topic_suffix="ct6/total_negative_energy",
+    unit="kWh",
     groups=["igen_dtsd422"],
     print_format="{:0.2f}",
 )

--- a/deye_sensors_igen_dtsd422.py
+++ b/deye_sensors_igen_dtsd422.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from deye_sensor import SingleRegisterSensor, ComputedPowerSensor, DoubleRegisterSensor, ComputedSumSensor, SensorRegisterRange
+
+# CT1
+ct1_voltage_sensor = SingleRegisterSensor(
+    "CT1 Voltage", 0x01, 0.1, mqtt_topic_suffix=ac/ct1/voltage, unit=V, groups=[igen_dtsd422])
+
+# CT2
+ct2_voltage_sensor = SingleRegisterSensor(
+    "CT2 Voltage", 0x02, 0.1, mqtt_topic_suffix=ac/ct2/voltage, unit=V, groups=[igen_dtsd422])
+
+# CT3
+ct3_voltage_sensor = SingleRegisterSensor(
+    "CT3 Voltage", 0x03, 0.1, mqtt_topic_suffix=ac/ct3/voltage, unit=V, groups=[igen_dtsd422])
+
+# CT4
+ct4_voltage_sensor = SingleRegisterSensor(
+    "CT4 Voltage", 0x1001, 0.1, mqtt_topic_suffix=ac/ct4/voltage, unit=V, groups=[igen_dtsd422])
+
+# CT5
+ct5_voltage_sensor = SingleRegisterSensor(
+    "CT4 Voltage", 0x1002, 0.1, mqtt_topic_suffix=ac/ct5/voltage, unit=V, groups=[igen_dtsd422])
+
+# CT6
+ct6_voltage_sensor = SingleRegisterSensor(
+    "CT4 Voltage", 0x1003, 0.1, mqtt_topic_suffix=ac/ct6/voltage, unit=V, groups=[igen_dtsd422])
+
+
+igen_dtsd422_sensors = [
+  ct1_voltage_sensor,
+  ct2_voltage_sensor,
+  ct3_voltage_sensor,
+  ct4_voltage_sensor,
+  ct5_voltage_sensor,
+  ct6_voltage_sensor,
+]
+
+igen_dtsd422_register_ranges = [
+    SensorRegisterRange(group=igen_dtsd422_ct123, first_reg_address=0x01, last_reg_address=0x03),
+    SensorRegisterRange(group=igen_dtsd422_ct456, first_reg_address=0x1001, last_reg_address=0x1003),
+]

--- a/deye_sensors_igen_dtsd422.py
+++ b/deye_sensors_igen_dtsd422.py
@@ -19,27 +19,27 @@ from deye_sensor import SingleRegisterSensor, ComputedPowerSensor, DoubleRegiste
 
 # CT1
 ct1_voltage_sensor = SingleRegisterSensor(
-    "CT1 Voltage", 0x01, 0.1, mqtt_topic_suffix=ac/ct1/voltage, unit=V, groups=[igen_dtsd422])
+    "CT1 Voltage", 0x01, 0.1, mqtt_topic_suffix="ac/ct1/voltage", unit="V", groups=["igen_dtsd422"])
 
 # CT2
 ct2_voltage_sensor = SingleRegisterSensor(
-    "CT2 Voltage", 0x02, 0.1, mqtt_topic_suffix=ac/ct2/voltage, unit=V, groups=[igen_dtsd422])
+    "CT2 Voltage", 0x02, 0.1, mqtt_topic_suffix="ac/ct2/voltage", unit="V", groups=["igen_dtsd422"])
 
 # CT3
 ct3_voltage_sensor = SingleRegisterSensor(
-    "CT3 Voltage", 0x03, 0.1, mqtt_topic_suffix=ac/ct3/voltage, unit=V, groups=[igen_dtsd422])
+    "CT3 Voltage", 0x03, 0.1, mqtt_topic_suffix="ac/ct3/voltage", unit="V", groups=["igen_dtsd422"])
 
 # CT4
 ct4_voltage_sensor = SingleRegisterSensor(
-    "CT4 Voltage", 0x1001, 0.1, mqtt_topic_suffix=ac/ct4/voltage, unit=V, groups=[igen_dtsd422])
+    "CT4 Voltage", 0x1001, 0.1, mqtt_topic_suffix="ac/ct4/voltage", unit="V", groups=["igen_dtsd422"])
 
 # CT5
 ct5_voltage_sensor = SingleRegisterSensor(
-    "CT4 Voltage", 0x1002, 0.1, mqtt_topic_suffix=ac/ct5/voltage, unit=V, groups=[igen_dtsd422])
+    "CT5 Voltage", 0x1002, 0.1, mqtt_topic_suffix="ac/ct5/voltage", unit="V", groups=["igen_dtsd422"])
 
 # CT6
 ct6_voltage_sensor = SingleRegisterSensor(
-    "CT4 Voltage", 0x1003, 0.1, mqtt_topic_suffix=ac/ct6/voltage, unit=V, groups=[igen_dtsd422])
+    "CT6 Voltage", 0x1003, 0.1, mqtt_topic_suffix="ac/ct6/voltage", unit="V", groups=["igen_dtsd422"])
 
 
 igen_dtsd422_sensors = [
@@ -52,6 +52,6 @@ igen_dtsd422_sensors = [
 ]
 
 igen_dtsd422_register_ranges = [
-    SensorRegisterRange(group=igen_dtsd422_ct123, first_reg_address=0x01, last_reg_address=0x03),
-    SensorRegisterRange(group=igen_dtsd422_ct456, first_reg_address=0x1001, last_reg_address=0x1003),
+    SensorRegisterRange(group="igen_dtsd422", first_reg_address=0x01, last_reg_address=0x03),
+    SensorRegisterRange(group="igen_dtsd422", first_reg_address=0x1001, last_reg_address=0x1003),
 ]

--- a/deye_sensors_igen_dtsd422.py
+++ b/deye_sensors_igen_dtsd422.py
@@ -15,43 +15,677 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from deye_sensor import SingleRegisterSensor, ComputedPowerSensor, DoubleRegisterSensor, ComputedSumSensor, SensorRegisterRange
+from deye_sensor import (
+    SingleRegisterSensor,
+    ComputedPowerSensor,
+    DoubleRegisterSensor,
+    ComputedSumSensor,
+    SensorRegisterRange,
+)
+
+#
+# Initial IGEN DTSD-422-D3 support.
+#
+# Todo:
+# * Daily Values for Positive and Negative energy are missing, can't find them.
+# * Is the direction calculation handled correctly? Or is something wrong here?
+# * Need to verify data is still read correctly when double reg values exceed one
+#   register
+# * There are some more informational registers, e.g. Manufacturing Date, serial etc. which
+#   we're ignoring for now. Maybe add?
+#
+
+
+class SingleDirectionRegisterSensor(SingleRegisterSensor):
+    """
+    Power meter sensor with value stored as 10-bit integer in a single Modbus register and the first byte
+    indicating power direction.
+    """
+
+    def read_value(self, registers: dict[int, int]):
+        if self.reg_address in registers:
+            reg_value = (
+                int.from_bytes(registers[self.reg_address], "big", signed=self.signed)
+                & 0x7FFF
+            )
+            # If highest bit is set, we've got a negative value
+            if bool(
+                (
+                    int.from_bytes(
+                        registers[self.reg_address], "big", signed=self.signed
+                    )
+                    & 0x8000
+                )
+                >> 15
+            ):
+                return -1 * reg_value * self.factor + self.offset
+            else:
+                return reg_value * self.factor + self.offset
+        else:
+            return None
+
+
+class DoubleDirectionRegisterSensor(DoubleRegisterSensor):
+    """
+    Power meter sensor with value stored as 32-bit integer in two Modbus registers and the energy flow direction
+    stored in the first Modbus register. High and Low words are swapped compared to the normal DoubleRegisterSensor.
+    Highest bit gives energy direction.
+    """
+
+    def read_value(self, registers: dict[int, int]):
+        high_word_reg_address = self.reg_address
+        low_word_reg_address = self.reg_address + 1
+        if low_word_reg_address in registers and high_word_reg_address in registers:
+            low_word = registers[low_word_reg_address]
+            high_word = registers[high_word_reg_address]
+            reg_value = (
+                int.from_bytes(high_word + low_word, "big", signed=self.signed)
+                & 0x7FFFFFFF
+            )
+            # If highest bit is set, we've got a negative value
+            if bool(
+                (
+                    int.from_bytes(high_word + low_word, "big", signed=self.signed)
+                    & 0x80000000
+                )
+                >> 31
+            ):
+                return -1 * reg_value * self.factor + self.offset
+            else:
+                return reg_value * self.factor + self.offset
+        else:
+            return None
+
 
 # CT1
 ct1_voltage_sensor = SingleRegisterSensor(
-    "CT1 Voltage", 0x01, 0.1, mqtt_topic_suffix="ac/ct1/voltage", unit="V", groups=["igen_dtsd422"])
+    "Voltage CT1",
+    0x01,
+    0.1,
+    mqtt_topic_suffix="ct1/voltage",
+    unit="V",
+    groups=["igen_dtsd422"],
+)
+ct1_current_sensor = DoubleDirectionRegisterSensor(
+    "Current CT1",
+    0x07,
+    0.001,
+    mqtt_topic_suffix="ct1/current",
+    unit="A",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+ct1_active_power_sensor = DoubleDirectionRegisterSensor(
+    "Active Power CT1",
+    0x0F,
+    1,
+    mqtt_topic_suffix="ct1/active_power",
+    unit="W",
+    groups=["igen_dtsd422"],
+)
+ct1_reactive_power_sensor = DoubleDirectionRegisterSensor(
+    "Reactive Power CT1",
+    0x17,
+    1,
+    mqtt_topic_suffix="ct1/reactive_power",
+    unit="Var",
+    groups=["igen_dtsd422"],
+)
+ct1_apparent_power_sensor = DoubleDirectionRegisterSensor(
+    "Apparent Power CT1",
+    0x1F,
+    1,
+    mqtt_topic_suffix="ct1/apparent_power",
+    unit="VA",
+    groups=["igen_dtsd422"],
+)
+ct1_power_factor_sensor = SingleDirectionRegisterSensor(
+    "Power Factor CT1",
+    0x26,
+    0.001,
+    mqtt_topic_suffix="ct1/power_factor",
+    groups=["igen_dtsd422"],
+)
+ct1_total_positive_energy = SingleRegisterSensor(
+    "Total Positive Energy CT1",
+    0x3F,
+    0.01,
+    mqtt_topic_suffix="ct1/total_positive_energy",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+ct1_total_negative_energy = SingleRegisterSensor(
+    "Total Negative Energy CT1",
+    0x49,
+    0.01,
+    mqtt_topic_suffix="ct1/total_negative_energy",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
 
 # CT2
 ct2_voltage_sensor = SingleRegisterSensor(
-    "CT2 Voltage", 0x02, 0.1, mqtt_topic_suffix="ac/ct2/voltage", unit="V", groups=["igen_dtsd422"])
+    "Voltage CT2",
+    0x02,
+    0.1,
+    mqtt_topic_suffix="ct2/voltage",
+    unit="V",
+    groups=["igen_dtsd422"],
+)
+ct2_current_sensor = DoubleDirectionRegisterSensor(
+    "Current CT2",
+    0x09,
+    0.001,
+    mqtt_topic_suffix="ct2/current",
+    unit="A",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+ct2_active_power_sensor = DoubleDirectionRegisterSensor(
+    "Active Power CT2",
+    0x11,
+    1,
+    mqtt_topic_suffix="ct2/active_power",
+    unit="W",
+    groups=["igen_dtsd422"],
+)
+ct2_reactive_power_sensor = DoubleDirectionRegisterSensor(
+    "Reactive Power CT2",
+    0x19,
+    1,
+    mqtt_topic_suffix="ct2/reactive_power",
+    unit="Var",
+    groups=["igen_dtsd422"],
+)
+ct2_apparent_power_sensor = DoubleDirectionRegisterSensor(
+    "Apparent Power CT2",
+    0x21,
+    1,
+    mqtt_topic_suffix="ct2/apparent_power",
+    unit="VA",
+    groups=["igen_dtsd422"],
+)
+ct2_power_factor_sensor = SingleDirectionRegisterSensor(
+    "Power Factor CT2",
+    0x27,
+    0.001,
+    mqtt_topic_suffix="ct2/power_factor",
+    groups=["igen_dtsd422"],
+)
+ct2_total_positive_energy = SingleRegisterSensor(
+    "Total Positive Energy CT2",
+    0x53,
+    0.01,
+    mqtt_topic_suffix="ct2/total_positive_energy",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+ct2_total_negative_energy = SingleRegisterSensor(
+    "Total Negative Energy CT2",
+    0x5D,
+    0.01,
+    mqtt_topic_suffix="ct2/total_negative_energy",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
 
 # CT3
 ct3_voltage_sensor = SingleRegisterSensor(
-    "CT3 Voltage", 0x03, 0.1, mqtt_topic_suffix="ac/ct3/voltage", unit="V", groups=["igen_dtsd422"])
+    "Voltage CT3",
+    0x03,
+    0.1,
+    mqtt_topic_suffix="ct3/voltage",
+    unit="V",
+    groups=["igen_dtsd422"],
+)
+ct3_current_sensor = DoubleDirectionRegisterSensor(
+    "Current CT3",
+    0x0B,
+    0.001,
+    mqtt_topic_suffix="ct3/current",
+    unit="A",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+ct3_active_power_sensor = DoubleDirectionRegisterSensor(
+    "Active Power CT3",
+    0x13,
+    1,
+    mqtt_topic_suffix="ct3/active_power",
+    unit="W",
+    groups=["igen_dtsd422"],
+)
+ct3_reactive_power_sensor = DoubleDirectionRegisterSensor(
+    "Reactive Power CT3",
+    0x1B,
+    1,
+    mqtt_topic_suffix="ct3/reactive_power",
+    unit="Var",
+    groups=["igen_dtsd422"],
+)
+ct3_apparent_power_sensor = DoubleDirectionRegisterSensor(
+    "Apparent Power CT3",
+    0x23,
+    1,
+    mqtt_topic_suffix="ct3/apparent_power",
+    unit="VA",
+    groups=["igen_dtsd422"],
+)
+ct3_power_factor_sensor = SingleDirectionRegisterSensor(
+    "Power Factor CT3",
+    0x28,
+    0.001,
+    mqtt_topic_suffix="ct3/power_factor",
+    groups=["igen_dtsd422"],
+)
+ct3_total_positive_energy = SingleRegisterSensor(
+    "Total Positive Energy CT3",
+    0x67,
+    0.01,
+    mqtt_topic_suffix="ct3/total_positive_energy",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+ct3_total_negative_energy = SingleRegisterSensor(
+    "Total Negative Energy CT3",
+    0x71,
+    0.01,
+    mqtt_topic_suffix="ct3/total_negative_energy",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
 
 # CT4
 ct4_voltage_sensor = SingleRegisterSensor(
-    "CT4 Voltage", 0x1001, 0.1, mqtt_topic_suffix="ac/ct4/voltage", unit="V", groups=["igen_dtsd422"])
+    "Voltage CT4",
+    0x1001,
+    0.1,
+    mqtt_topic_suffix="ct4/voltage",
+    unit="V",
+    groups=["igen_dtsd422"],
+)
+ct4_current_sensor = DoubleDirectionRegisterSensor(
+    "Current CT4",
+    0x1007,
+    0.001,
+    mqtt_topic_suffix="ct4/current",
+    unit="A",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+ct4_active_power_sensor = DoubleDirectionRegisterSensor(
+    "Active Power CT4",
+    0x100F,
+    1,
+    mqtt_topic_suffix="ct4/active_power",
+    unit="W",
+    groups=["igen_dtsd422"],
+)
+ct4_reactive_power_sensor = DoubleDirectionRegisterSensor(
+    "Reactive Power CT4",
+    0x1017,
+    1,
+    mqtt_topic_suffix="ct4/reactive_power",
+    unit="Var",
+    groups=["igen_dtsd422"],
+)
+ct4_apparent_power_sensor = DoubleDirectionRegisterSensor(
+    "Apparent Power CT4",
+    0x101F,
+    1,
+    mqtt_topic_suffix="ct4/apparent_power",
+    unit="VA",
+    groups=["igen_dtsd422"],
+)
+ct4_power_factor_sensor = SingleDirectionRegisterSensor(
+    "Power Factor CT4",
+    0x1026,
+    0.001,
+    mqtt_topic_suffix="ct4/power_factor",
+    groups=["igen_dtsd422"],
+)
+ct4_total_positive_energy = SingleRegisterSensor(
+    "Total Positive Energy CT4",
+    0x103F,
+    0.01,
+    mqtt_topic_suffix="ct4/total_positive_energy",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+ct4_total_negative_energy = SingleRegisterSensor(
+    "Total Negative Energy CT4",
+    0x1049,
+    0.01,
+    mqtt_topic_suffix="ct4/total_negative_energy",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
 
 # CT5
 ct5_voltage_sensor = SingleRegisterSensor(
-    "CT5 Voltage", 0x1002, 0.1, mqtt_topic_suffix="ac/ct5/voltage", unit="V", groups=["igen_dtsd422"])
+    "Voltage CT5",
+    0x1002,
+    0.1,
+    mqtt_topic_suffix="ct5/voltage",
+    unit="V",
+    groups=["igen_dtsd422"],
+)
+ct5_current_sensor = DoubleDirectionRegisterSensor(
+    "Current CT5",
+    0x1009,
+    0.001,
+    mqtt_topic_suffix="ct5/current",
+    unit="A",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+ct5_active_power_sensor = DoubleDirectionRegisterSensor(
+    "Active Power CT5",
+    0x1011,
+    1,
+    mqtt_topic_suffix="ct5/active_power",
+    unit="W",
+    groups=["igen_dtsd422"],
+)
+ct5_reactive_power_sensor = DoubleDirectionRegisterSensor(
+    "Reactive Power CT5",
+    0x1019,
+    1,
+    mqtt_topic_suffix="ct5/reactive_power",
+    unit="Var",
+    groups=["igen_dtsd422"],
+)
+ct5_apparent_power_sensor = DoubleDirectionRegisterSensor(
+    "Apparent Power CT5",
+    0x1021,
+    1,
+    mqtt_topic_suffix="ct5/apparent_power",
+    unit="VA",
+    groups=["igen_dtsd422"],
+)
+ct5_power_factor_sensor = SingleDirectionRegisterSensor(
+    "Power Factor CT5",
+    0x1027,
+    0.001,
+    mqtt_topic_suffix="ct5/power_factor",
+    groups=["igen_dtsd422"],
+)
+ct5_total_positive_energy = SingleRegisterSensor(
+    "Total Positive Energy CT5",
+    0x1053,
+    0.01,
+    mqtt_topic_suffix="ct5/total_positive_energy",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+ct5_total_negative_energy = SingleRegisterSensor(
+    "Total Negative Energy CT5",
+    0x105D,
+    0.01,
+    mqtt_topic_suffix="ct5/total_negative_energy",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
 
 # CT6
 ct6_voltage_sensor = SingleRegisterSensor(
-    "CT6 Voltage", 0x1003, 0.1, mqtt_topic_suffix="ac/ct6/voltage", unit="V", groups=["igen_dtsd422"])
+    "Voltage CT6",
+    0x1003,
+    0.1,
+    mqtt_topic_suffix="ct6/voltage",
+    unit="V",
+    groups=["igen_dtsd422"],
+)
+ct6_current_sensor = DoubleDirectionRegisterSensor(
+    "Current CT6",
+    0x100B,
+    0.001,
+    mqtt_topic_suffix="ct6/current",
+    unit="A",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+ct6_active_power_sensor = DoubleDirectionRegisterSensor(
+    "Active Power CT6",
+    0x1013,
+    1,
+    mqtt_topic_suffix="ct6/active_power",
+    unit="W",
+    groups=["igen_dtsd422"],
+)
+ct6_reactive_power_sensor = DoubleDirectionRegisterSensor(
+    "Reactive Power CT6",
+    0x101B,
+    1,
+    mqtt_topic_suffix="ct6/reactive_power",
+    unit="Var",
+    groups=["igen_dtsd422"],
+)
+ct6_apparent_power_sensor = DoubleDirectionRegisterSensor(
+    "Apparent Power CT6",
+    0x1023,
+    1,
+    mqtt_topic_suffix="ct6/apparent_power",
+    unit="VA",
+    groups=["igen_dtsd422"],
+)
+ct6_power_factor_sensor = SingleDirectionRegisterSensor(
+    "Power Factor CT6",
+    0x1028,
+    0.001,
+    mqtt_topic_suffix="ct6/power_factor",
+    groups=["igen_dtsd422"],
+)
+ct6_total_positive_energy = SingleRegisterSensor(
+    "Total Positive Energy CT6",
+    0x1067,
+    0.01,
+    mqtt_topic_suffix="ct6/total_positive_energy",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+ct6_total_negative_energy = SingleRegisterSensor(
+    "Total Negative Energy CT6",
+    0x1071,
+    0.01,
+    mqtt_topic_suffix="ct6/total_negative_energy",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+
+# Total
+total_active_power_sensor = DoubleDirectionRegisterSensor(
+    "Total Active Power",
+    0x0D,
+    1,
+    mqtt_topic_suffix="total/active_power",
+    unit="W",
+    groups=["igen_dtsd422"],
+)
+total_active_power2_sensor = DoubleDirectionRegisterSensor(
+    "Total Active Power 2",
+    0x100D,
+    1,
+    mqtt_topic_suffix="total/active_power2",
+    unit="W",
+    groups=["igen_dtsd422"],
+)
+total_reactive_power_sensor = DoubleDirectionRegisterSensor(
+    "Total Reactive Power",
+    0x15,
+    1,
+    mqtt_topic_suffix="total/reactive_power",
+    unit="Var",
+    groups=["igen_dtsd422"],
+)
+total_reactive_power2_sensor = DoubleDirectionRegisterSensor(
+    "Total Reactive Power 2",
+    0x1015,
+    1,
+    mqtt_topic_suffix="total/reactive_power2",
+    unit="Var",
+    groups=["igen_dtsd422"],
+)
+total_apparent_power_sensor = DoubleDirectionRegisterSensor(
+    "Total Apparent Power",
+    0x1D,
+    1,
+    mqtt_topic_suffix="total/apparent_power",
+    unit="VA",
+    groups=["igen_dtsd422"],
+)
+total_apparent_power2_sensor = DoubleDirectionRegisterSensor(
+    "Total Apparent Power 2",
+    0x101D,
+    1,
+    mqtt_topic_suffix="total/apparent_power2",
+    unit="VA",
+    groups=["igen_dtsd422"],
+)
+total_positive_energy_sensor = SingleRegisterSensor(
+    "Total Positive Energy",
+    0x2B,
+    0.01,
+    mqtt_topic_suffix="total/positive_energy",
+    unit="kWh",
+    groups=["igen_dtsd422"],
+)
+total_positive_energy2_sensor = SingleRegisterSensor(
+    "Total Positive Energy 2",
+    0x102B,
+    0.01,
+    mqtt_topic_suffix="total/positive_energy2",
+    unit="kWh",
+    groups=["igen_dtsd422"],
+)
+total_negative_energy_sensor = SingleRegisterSensor(
+    "Total Negative Energy",
+    0x35,
+    0.01,
+    mqtt_topic_suffix="total/negative_energy",
+    unit="kWh",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+total_negative_energy2_sensor = SingleRegisterSensor(
+    "Total Negative Energy 2",
+    0x1035,
+    0.01,
+    mqtt_topic_suffix="total/negative_energy2",
+    unit="kWh",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+total_power_factor_sensor = SingleDirectionRegisterSensor(
+    "Power Factor",
+    0x25,
+    0.001,
+    mqtt_topic_suffix="total/power_factor",
+    groups=["igen_dtsd422"],
+)
+total_power_factor2_sensor = SingleDirectionRegisterSensor(
+    "Power Factor 2",
+    0x1025,
+    0.001,
+    mqtt_topic_suffix="total/power_factor2",
+    groups=["igen_dtsd422"],
+)
+total_frequency_sensor = SingleRegisterSensor(
+    "Frequency",
+    0x29,
+    0.01,
+    mqtt_topic_suffix="total/frequency",
+    unit="Hz",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
+total_frequency2_sensor = SingleRegisterSensor(
+    "Frequency 2",
+    0x1029,
+    0.01,
+    mqtt_topic_suffix="total/frequency2",
+    unit="Hz",
+    groups=["igen_dtsd422"],
+    print_format="{:0.2f}",
+)
 
 
 igen_dtsd422_sensors = [
-  ct1_voltage_sensor,
-  ct2_voltage_sensor,
-  ct3_voltage_sensor,
-  ct4_voltage_sensor,
-  ct5_voltage_sensor,
-  ct6_voltage_sensor,
+    ct1_voltage_sensor,
+    ct1_current_sensor,
+    ct1_active_power_sensor,
+    ct1_reactive_power_sensor,
+    ct1_apparent_power_sensor,
+    ct1_power_factor_sensor,
+    ct1_total_positive_energy,
+    ct1_total_negative_energy,
+    ct2_voltage_sensor,
+    ct2_current_sensor,
+    ct2_active_power_sensor,
+    ct2_reactive_power_sensor,
+    ct2_apparent_power_sensor,
+    ct2_power_factor_sensor,
+    ct2_total_positive_energy,
+    ct2_total_negative_energy,
+    ct3_voltage_sensor,
+    ct3_current_sensor,
+    ct3_active_power_sensor,
+    ct3_reactive_power_sensor,
+    ct3_apparent_power_sensor,
+    ct3_power_factor_sensor,
+    ct3_total_positive_energy,
+    ct3_total_negative_energy,
+    ct4_voltage_sensor,
+    ct4_current_sensor,
+    ct4_active_power_sensor,
+    ct4_reactive_power_sensor,
+    ct4_apparent_power_sensor,
+    ct4_power_factor_sensor,
+    ct4_total_positive_energy,
+    ct4_total_negative_energy,
+    ct5_voltage_sensor,
+    ct5_current_sensor,
+    ct5_active_power_sensor,
+    ct5_reactive_power_sensor,
+    ct5_apparent_power_sensor,
+    ct5_power_factor_sensor,
+    ct5_total_positive_energy,
+    ct5_total_negative_energy,
+    ct6_voltage_sensor,
+    ct6_current_sensor,
+    ct6_active_power_sensor,
+    ct6_reactive_power_sensor,
+    ct6_apparent_power_sensor,
+    ct6_power_factor_sensor,
+    ct6_total_positive_energy,
+    ct6_total_negative_energy,
+    total_active_power_sensor,
+    total_active_power2_sensor,
+    total_reactive_power_sensor,
+    total_reactive_power2_sensor,
+    total_apparent_power_sensor,
+    total_apparent_power2_sensor,
+    total_positive_energy_sensor,
+    total_positive_energy2_sensor,
+    total_negative_energy_sensor,
+    total_negative_energy2_sensor,
+    total_power_factor_sensor,
+    total_power_factor2_sensor,
+    total_frequency_sensor,
+    total_frequency2_sensor,
 ]
 
 igen_dtsd422_register_ranges = [
-    SensorRegisterRange(group="igen_dtsd422", first_reg_address=0x01, last_reg_address=0x03),
-    SensorRegisterRange(group="igen_dtsd422", first_reg_address=0x1001, last_reg_address=0x1003),
+    SensorRegisterRange(
+        group="igen_dtsd422", first_reg_address=0x01, last_reg_address=0x64
+    ),
+    SensorRegisterRange(
+        group="igen_dtsd422", first_reg_address=0x65, last_reg_address=0xA1
+    ),
+    SensorRegisterRange(
+        group="igen_dtsd422", first_reg_address=0x1001, last_reg_address=0x1064
+    ),
+    SensorRegisterRange(
+        group="igen_dtsd422", first_reg_address=0x1065, last_reg_address=0x10A1
+    ),
 ]

--- a/docs/metric_group_igen_dtsd422.md
+++ b/docs/metric_group_igen_dtsd422.md
@@ -6,48 +6,48 @@
 |Reactive Power CT1|23,24|`ct1/reactive_power`|Var|
 |Apparent Power CT1|31,32|`ct1/apparent_power`|VA|
 |Power Factor CT1|38|`ct1/power_factor`||
-|Total Positive Energy CT1|63|`ct1/total_positive_energy`||
-|Total Negative Energy CT1|73|`ct1/total_negative_energy`||
+|Total Positive Energy CT1|63|`ct1/total_positive_energy`|kWh|
+|Total Negative Energy CT1|73|`ct1/total_negative_energy`|kWh|
 |Voltage CT2|2|`ct2/voltage`|V|
 |Current CT2|9,10|`ct2/current`|A|
 |Active Power CT2|17,18|`ct2/active_power`|W|
 |Reactive Power CT2|25,26|`ct2/reactive_power`|Var|
 |Apparent Power CT2|33,34|`ct2/apparent_power`|VA|
 |Power Factor CT2|39|`ct2/power_factor`||
-|Total Positive Energy CT2|83|`ct2/total_positive_energy`||
-|Total Negative Energy CT2|93|`ct2/total_negative_energy`||
+|Total Positive Energy CT2|83|`ct2/total_positive_energy`|kWh|
+|Total Negative Energy CT2|93|`ct2/total_negative_energy`|kWh|
 |Voltage CT3|3|`ct3/voltage`|V|
 |Current CT3|11,12|`ct3/current`|A|
 |Active Power CT3|19,20|`ct3/active_power`|W|
 |Reactive Power CT3|27,28|`ct3/reactive_power`|Var|
 |Apparent Power CT3|35,36|`ct3/apparent_power`|VA|
 |Power Factor CT3|40|`ct3/power_factor`||
-|Total Positive Energy CT3|103|`ct3/total_positive_energy`||
-|Total Negative Energy CT3|113|`ct3/total_negative_energy`||
+|Total Positive Energy CT3|103|`ct3/total_positive_energy`|kWh|
+|Total Negative Energy CT3|113|`ct3/total_negative_energy`|kWh|
 |Voltage CT4|4097|`ct4/voltage`|V|
 |Current CT4|4103,4104|`ct4/current`|A|
 |Active Power CT4|4111,4112|`ct4/active_power`|W|
 |Reactive Power CT4|4119,4120|`ct4/reactive_power`|Var|
 |Apparent Power CT4|4127,4128|`ct4/apparent_power`|VA|
 |Power Factor CT4|4134|`ct4/power_factor`||
-|Total Positive Energy CT4|4159|`ct4/total_positive_energy`||
-|Total Negative Energy CT4|4169|`ct4/total_negative_energy`||
+|Total Positive Energy CT4|4159|`ct4/total_positive_energy`|kWh|
+|Total Negative Energy CT4|4169|`ct4/total_negative_energy`|kWh|
 |Voltage CT5|4098|`ct5/voltage`|V|
 |Current CT5|4105,4106|`ct5/current`|A|
 |Active Power CT5|4113,4114|`ct5/active_power`|W|
 |Reactive Power CT5|4121,4122|`ct5/reactive_power`|Var|
 |Apparent Power CT5|4129,4130|`ct5/apparent_power`|VA|
 |Power Factor CT5|4135|`ct5/power_factor`||
-|Total Positive Energy CT5|4179|`ct5/total_positive_energy`||
-|Total Negative Energy CT5|4189|`ct5/total_negative_energy`||
+|Total Positive Energy CT5|4179|`ct5/total_positive_energy`|kWh|
+|Total Negative Energy CT5|4189|`ct5/total_negative_energy`|kWh|
 |Voltage CT6|4099|`ct6/voltage`|V|
 |Current CT6|4107,4108|`ct6/current`|A|
 |Active Power CT6|4115,4116|`ct6/active_power`|W|
 |Reactive Power CT6|4123,4124|`ct6/reactive_power`|Var|
 |Apparent Power CT6|4131,4132|`ct6/apparent_power`|VA|
 |Power Factor CT6|4136|`ct6/power_factor`||
-|Total Positive Energy CT6|4199|`ct6/total_positive_energy`||
-|Total Negative Energy CT6|4209|`ct6/total_negative_energy`||
+|Total Positive Energy CT6|4199|`ct6/total_positive_energy`|kWh|
+|Total Negative Energy CT6|4209|`ct6/total_negative_energy`|kWh|
 |Total Active Power|13,14|`total/active_power`|W|
 |Total Active Power 2|4109,4110|`total/active_power2`|W|
 |Total Reactive Power|21,22|`total/reactive_power`|Var|

--- a/docs/metric_group_igen_dtsd422.md
+++ b/docs/metric_group_igen_dtsd422.md
@@ -1,0 +1,64 @@
+|Metric|Modbus address|MQTT topic suffix|Unit|
+|---|:-:|---|:-:|
+|Voltage CT1|1|`ct1/voltage`|V|
+|Current CT1|7,8|`ct1/current`|A|
+|Active Power CT1|15,16|`ct1/active_power`|W|
+|Reactive Power CT1|23,24|`ct1/reactive_power`|Var|
+|Apparent Power CT1|31,32|`ct1/apparent_power`|VA|
+|Power Factor CT1|38|`ct1/power_factor`||
+|Total Positive Energy CT1|63|`ct1/total_positive_energy`||
+|Total Negative Energy CT1|73|`ct1/total_negative_energy`||
+|Voltage CT2|2|`ct2/voltage`|V|
+|Current CT2|9,10|`ct2/current`|A|
+|Active Power CT2|17,18|`ct2/active_power`|W|
+|Reactive Power CT2|25,26|`ct2/reactive_power`|Var|
+|Apparent Power CT2|33,34|`ct2/apparent_power`|VA|
+|Power Factor CT2|39|`ct2/power_factor`||
+|Total Positive Energy CT2|83|`ct2/total_positive_energy`||
+|Total Negative Energy CT2|93|`ct2/total_negative_energy`||
+|Voltage CT3|3|`ct3/voltage`|V|
+|Current CT3|11,12|`ct3/current`|A|
+|Active Power CT3|19,20|`ct3/active_power`|W|
+|Reactive Power CT3|27,28|`ct3/reactive_power`|Var|
+|Apparent Power CT3|35,36|`ct3/apparent_power`|VA|
+|Power Factor CT3|40|`ct3/power_factor`||
+|Total Positive Energy CT3|103|`ct3/total_positive_energy`||
+|Total Negative Energy CT3|113|`ct3/total_negative_energy`||
+|Voltage CT4|4097|`ct4/voltage`|V|
+|Current CT4|4103,4104|`ct4/current`|A|
+|Active Power CT4|4111,4112|`ct4/active_power`|W|
+|Reactive Power CT4|4119,4120|`ct4/reactive_power`|Var|
+|Apparent Power CT4|4127,4128|`ct4/apparent_power`|VA|
+|Power Factor CT4|4134|`ct4/power_factor`||
+|Total Positive Energy CT4|4159|`ct4/total_positive_energy`||
+|Total Negative Energy CT4|4169|`ct4/total_negative_energy`||
+|Voltage CT5|4098|`ct5/voltage`|V|
+|Current CT5|4105,4106|`ct5/current`|A|
+|Active Power CT5|4113,4114|`ct5/active_power`|W|
+|Reactive Power CT5|4121,4122|`ct5/reactive_power`|Var|
+|Apparent Power CT5|4129,4130|`ct5/apparent_power`|VA|
+|Power Factor CT5|4135|`ct5/power_factor`||
+|Total Positive Energy CT5|4179|`ct5/total_positive_energy`||
+|Total Negative Energy CT5|4189|`ct5/total_negative_energy`||
+|Voltage CT6|4099|`ct6/voltage`|V|
+|Current CT6|4107,4108|`ct6/current`|A|
+|Active Power CT6|4115,4116|`ct6/active_power`|W|
+|Reactive Power CT6|4123,4124|`ct6/reactive_power`|Var|
+|Apparent Power CT6|4131,4132|`ct6/apparent_power`|VA|
+|Power Factor CT6|4136|`ct6/power_factor`||
+|Total Positive Energy CT6|4199|`ct6/total_positive_energy`||
+|Total Negative Energy CT6|4209|`ct6/total_negative_energy`||
+|Total Active Power|13,14|`total/active_power`|W|
+|Total Active Power 2|4109,4110|`total/active_power2`|W|
+|Total Reactive Power|21,22|`total/reactive_power`|Var|
+|Total Reactive Power 2|4117,4118|`total/reactive_power2`|Var|
+|Total Apparent Power|29,30|`total/apparent_power`|VA|
+|Total Apparent Power 2|4125,4126|`total/apparent_power2`|VA|
+|Total Positive Energy|43|`total/positive_energy`|kWh|
+|Total Positive Energy 2|4139|`total/positive_energy2`|kWh|
+|Total Negative Energy|53|`total/negative_energy`|kWh|
+|Total Negative Energy 2|4149|`total/negative_energy2`|kWh|
+|Power Factor|37|`total/power_factor`||
+|Power Factor 2|4133|`total/power_factor2`||
+|Frequency|41|`total/frequency`|Hz|
+|Frequency 2|4137|`total/frequency2`|Hz|


### PR DESCRIPTION
Add support for the DTSD422-D3 smartmeter which is normaly used to get grid/consumption information for the solarman platform.