### PR TITLE
fix issue with loading special characters from env file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test-mqtt:
 	python -m unittest "deye_mqtt_inttest.py"
 
 run:
-	@bash -c "$$(cat config.env | xargs) python deye_docker_entrypoint.py"
+	@bash -c "set -a; source config.env; python deye_docker_entrypoint.py"
 
 $(ARCHS:%=docker-build-%): docker-build-%:
 	@docker buildx create --use


### PR DESCRIPTION
I faces some issues with loading the password in local run for development testing. The special characters contained in the password caused some unwanted line splits.
My solution was to set auto-export of loaded environment variables via `set -a`and then simply source the env file.