### PR TITLE
Remove unused install packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@
 FROM python:3.10.10-alpine3.16 as builder
 
 WORKDIR /build
-RUN apk add gcc alpine-sdk
 COPY requirements.txt ./
 RUN pip install --no-cache-dir --target . -r requirements.txt
 


### PR DESCRIPTION
As far as I can see the installed packaged ` gcc` and ` alpine-sdk` in the `Dockerfile` are not used or required, so suggest to remove them.