### PR TITLE
Stop publishing on first error

### DIFF
--- a/src/deye_mqtt.py
+++ b/src/deye_mqtt.py
@@ -27,6 +27,11 @@ from deye_observation import Observation
 import time
 
 
+class DeyeMqttPublishError(Exception):
+    def __init__(self, message: str):
+        self.message = message
+
+
 class DeyeMqttClient:
     def __init__(self, config: DeyeConfig):
         self.__log = logging.getLogger(DeyeMqttClient.__name__)
@@ -91,11 +96,11 @@ class DeyeMqttClient:
             info = self.__mqtt_client.publish(mqtt_topic, value, qos=1)
             info.wait_for_publish(self.__mqtt_timeout)
         except ValueError as e:
-            self.__log.error("MQTT outgoing queue is full: %s", str(e))
+            raise DeyeMqttPublishError(f"MQTT outgoing queue is full: {str(e)}")
         except RuntimeError as e:
-            self.__log.error("Unknown MQTT publishing error: %s", str(e))
+            raise DeyeMqttPublishError(f"Unknown MQTT publishing error: {str(e)}")
         except OSError as e:
-            self.__log.error("MQTT connection error %s", str(e))
+            raise DeyeMqttPublishError(f"MQTT connection error: {str(e)}")
 
     def publish_observation(self, observation: Observation):
         if observation.sensor.mqtt_topic_suffix:

--- a/src/deye_mqtt_publisher.py
+++ b/src/deye_mqtt_publisher.py
@@ -19,7 +19,7 @@ import logging
 
 from deye_config import DeyeConfig
 from deye_events import DeyeEvent, DeyeEventProcessor, DeyeLoggerStatusEvent, DeyeObservationEvent
-from deye_mqtt import DeyeMqttClient
+from deye_mqtt import DeyeMqttClient, DeyeMqttPublishError
 
 
 class DeyeMqttPublisher(DeyeEventProcessor):
@@ -40,12 +40,15 @@ class DeyeMqttPublisher(DeyeEventProcessor):
 
     def process(self, events: list[DeyeEvent]):
         for event in events:
-            if isinstance(event, DeyeObservationEvent):
-                self.__mqtt_client.publish_observation(event.observation)
-            elif isinstance(event, DeyeLoggerStatusEvent):
-                self.__mqtt_client.publish_logger_status(event.online)
-            else:
-                self.__log.warning(f"Unsupported event type {event.__class__}")
+            try:
+                if isinstance(event, DeyeObservationEvent):
+                    self.__mqtt_client.publish_observation(event.observation)
+                elif isinstance(event, DeyeLoggerStatusEvent):
+                    self.__mqtt_client.publish_logger_status(event.online)
+                else:
+                    self.__log.warning(f"Unsupported event type {event.__class__}")
+            except DeyeMqttPublishError as e:
+                self.__log.error(e.message)
 
     def get_mqtt_client(self) -> DeyeMqttClient:
         return self.__mqtt_client

--- a/src/deye_mqtt_publisher.py
+++ b/src/deye_mqtt_publisher.py
@@ -49,6 +49,7 @@ class DeyeMqttPublisher(DeyeEventProcessor):
                     self.__log.warning(f"Unsupported event type {event.__class__}")
             except DeyeMqttPublishError as e:
                 self.__log.error(e.message)
+                break
 
     def get_mqtt_client(self) -> DeyeMqttClient:
         return self.__mqtt_client


### PR DESCRIPTION
It does not make sense to continue publishing to mqtt after getting publishing error. The subsequent publish calls also fail and only spam the log.