### PR TITLE
Adding Modbus addresses for BMS metrics determined for deye_sg03lp1 

### DIFF
--- a/docs/metric_group_deye_sg03lp1_bms.md
+++ b/docs/metric_group_deye_sg03lp1_bms.md
@@ -1,0 +1,10 @@
+|Metric|MQTT topic suffix|Unit|Modbus address (dec)|Modbus address (hex)|Modbus data type|Scale factor|
+|---|---|:-:|:-:|:-:|:-:|:-:|
+|BMS1 Charging Voltage|`bms/1/charging_voltage`|V|312|138|U_WORD|0.01|
+|BMS1 Discharge Voltage|`bms/1/discharge_voltage`|V|313|139|U_WORD|0.01|
+|BMS1 Charge Current Limit|`bms/1/charge_current_limit`|A|314|13a|U_WORD|1|
+|BMS1 Discharge Current Limit|`bms/1/discharge_current_limit`|A|315|13b|U_WORD|1|
+|BMS1 SOC|`bms/1/soc`|%|316|13c|U_WORD|1|
+|BMS1 Voltage|`bms/1/voltage`|V|317|13d|U_WORD|0.01|
+|BMS1 Current|`bms/1/current`|A|318|13e|S_WORD|1|
+|BMS1 Temp|`bms/1/temp`|°C|319|13f|U_WORD|0.1|


### PR DESCRIPTION
Hello

I've been trying to find BMS metrics definitions for SG03LP1 and found your repository, which looked really helpful, while your data didn't have table for addresses for my inverter I was able to determine this experimentally from my inverter, and I think this might be useful to other people.
So, I think it would be nice if you add this definition to your list.

Regards,
Sviat