### PR TITLE
Make modbus  available to plugins

### DIFF
--- a/src/deye_plugin_loader.py
+++ b/src/deye_plugin_loader.py
@@ -24,12 +24,14 @@ import os
 from deye_config import DeyeConfig
 from deye_mqtt import DeyeMqttClient
 from deye_events import DeyeEventProcessor
+from deye_modbus import DeyeModbus
 
 
 class DeyePluginContext:
-    def __init__(self, config: DeyeConfig, mqtt_client: DeyeMqttClient):
+    def __init__(self, config: DeyeConfig, mqtt_client: DeyeMqttClient, modbus: DeyeModbus):
         self.config = config
         self.mqtt_client = mqtt_client
+        self.modbus = modbus
 
 
 class DeyePluginLoader:

--- a/src/deye_processor_factory.py
+++ b/src/deye_processor_factory.py
@@ -28,15 +28,15 @@ from deye_active_power_regulation import DeyeActivePowerRegulationEventProcessor
 from deye_sensor import Sensor
 from deye_plugin_loader import DeyePluginContext, DeyePluginLoader
 from deye_multi_inverter_data_aggregator import DeyeMultiInverterDataAggregator
-
+from deye_modbus import DeyeModbus
 
 class DeyeProcessorFactory:
-    def __init__(self, config: DeyeConfig, mqtt_client: DeyeMqttClient):
+    def __init__(self, config: DeyeConfig, mqtt_client: DeyeMqttClient, modbus: DeyeModbus):
         self.__log = logging.getLogger(DeyeProcessorFactory.__name__)
         self.__config = config
         self.__mqtt_client = mqtt_client
         self.__first_run = True
-        plugin_context = DeyePluginContext(config, mqtt_client)
+        plugin_context = DeyePluginContext(config, mqtt_client, modbus)
         self.plugin_loader = DeyePluginLoader(config)
         self.plugin_loader.load_plugins(plugin_context)
 

--- a/src/deye_processor_factory.py
+++ b/src/deye_processor_factory.py
@@ -31,18 +31,18 @@ from deye_multi_inverter_data_aggregator import DeyeMultiInverterDataAggregator
 from deye_modbus import DeyeModbus
 
 class DeyeProcessorFactory:
-    def __init__(self, config: DeyeConfig, mqtt_client: DeyeMqttClient, modbus: DeyeModbus):
+    def __init__(self, config: DeyeConfig, mqtt_client: DeyeMqttClient):
         self.__log = logging.getLogger(DeyeProcessorFactory.__name__)
         self.__config = config
         self.__mqtt_client = mqtt_client
         self.__first_run = True
-        plugin_context = DeyePluginContext(config, mqtt_client, modbus)
         self.plugin_loader = DeyePluginLoader(config)
-        self.plugin_loader.load_plugins(plugin_context)
 
     def create_processors(
         self, logger_config: DeyeLoggerConfig, modbus: DeyeModbus, sensors: list[Sensor]
     ) -> list[DeyeEventProcessor]:
+        plugin_context = DeyePluginContext(self.__config, self.__mqtt_client, modbus)
+        self.plugin_loader.load_plugins(plugin_context)
         processors = (
             self.__create_builtin_processors(logger_config, modbus, sensors) + self.plugin_loader.get_event_processors()
         )


### PR DESCRIPTION
This allows plugins to access the modbus by adding `DeyeModbus` to `PluginContext`.