### PR TITLE
Adding the ability to control the "Solar Sell" setting by MQTT commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ METRIC_GROUPS = \
 	deye_sg01hp3_bms \
 	deye_sg01hp3_timeofuse \
 	deye_sg01hp3_systemtime \
+	deye_sg01hp3_settings \
 	aggregated
 GENERATE_DOCS_TARGETS = $(addprefix generate-docs-, $(METRIC_GROUPS))
 $(GENERATE_DOCS_TARGETS): generate-docs-%:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For LSE-3 Ethernet datalogger use `mbtcp` protocol
 | [Deye SG04LP3](https://deye.com/product/sun-5-6-8-10-12k-sg04lp3-eu/)                                           | tcp, at  | [deye_sg04lp3](docs/metric_group_deye_sg04lp3.md), [deye_sg04lp3_battery](docs/metric_group_deye_sg04lp3_battery.md), [deye_sg04lp3_ups](docs/metric_group_deye_sg04lp3_ups.md), [deye_sg04lp3_timeofuse](docs/metric_group_deye_sg04lp3_timeofuse.md), [deye_sg04lp3_generator](docs/metric_group_deye_sg04lp3_generator.md), [settings](docs/metric_group_settings.md), [deye_sg04lp3_systemtime](docs/metric_group_deye_sg04lp3_systemtime.md)|
 | [Deye SG01LP1](https://deye.com/product/sun-7-6-8k-sg01lp1-eu/)                                                 | tcp, at  | [deye_hybrid](docs/metric_group_deye_hybrid.md), [deye_hybrid_battery](docs/metric_group_deye_hybrid_battery.md), [deye_hybrid_bms](docs/metric_group_deye_hybrid_bms.md), [deye_hybrid_timeofuse](docs/metric_group_deye_hybrid_timeofuse.md), [settings](docs/metric_group_settings.md)                                                                                |
 | [Deye SG02LP1](https://deye.com/product/sun-7-6-8k-sg02lp1-eu-am2/)                                                 | tcp, at  | [deye_sg02lp1](docs/metric_group_deye_sg02lp1.md), [deye_sg02lp1_battery](docs/metric_group_deye_sg02lp1_battery.md), [deye_sg02lp1_bms](docs/metric_group_deye_sg02lp1_bms.md), [deye_sg02lp1_timeofuse](docs/metric_group_deye_sg02lp1_timeofuse.md), [settings](docs/metric_group_settings.md)                                                                                |
-| [Deye SG01HP3](https://deye.com/product/sun-5-6-8-10-12-15-20-25k-sg01hp3-eu-am2/)                              | tcp, at  | [deye_sg01hp3](docs/metric_group_deye_sg01hp3.md), [deye_sg01hp3_battery](docs/metric_group_deye_sg01hp3_battery.md), [deye_sg01hp3_bms](docs/metric_group_deye_sg01hp3_bms.md), [deye_sg01hp3_ups](docs/metric_group_deye_sg01hp3_ups.md), [deye_sg01hp3_generator](docs/metric_group_deye_sg01hp3_generator.md), [settings](docs/metric_group_settings.md), [deye_sg01hp3_systemtime](docs/metric_group_deye_sg01hp3_systemtime.md)|
+| [Deye SG01HP3](https://deye.com/product/sun-5-6-8-10-12-15-20-25k-sg01hp3-eu-am2/)                              | tcp, at  | [deye_sg01hp3](docs/metric_group_deye_sg01hp3.md), [deye_sg01hp3_battery](docs/metric_group_deye_sg01hp3_battery.md), [deye_sg01hp3_bms](docs/metric_group_deye_sg01hp3_bms.md), [deye_sg01hp3_ups](docs/metric_group_deye_sg01hp3_ups.md), [deye_sg01hp3_generator](docs/metric_group_deye_sg01hp3_generator.md), [settings](docs/metric_group_settings.md), [deye_sg01hp3_systemtime](docs/metric_group_deye_sg01hp3_systemtime.md), [deye_sg01hp3_settings](metric_group_deye_sg01hp3_settings.md)|
 | [Deye SG03LP1](https://deye.com/product/sun-3-6-5-6k-sg03lp1-eu/)                              | tcp, at  | [deye_sg03lp1](docs/metric_group_deye_sg03lp1.md), [deye_hybrid_battery](docs/metric_group_deye_hybrid_battery.md), [deye_hybrid_bms](docs/metric_group_deye_hybrid_bms.md), [deye_hybrid_timeofuse](docs/metric_group_deye_hybrid_timeofuse.md), [settings](docs/metric_group_settings.md)                               
 
 
@@ -180,6 +180,7 @@ All configuration options are controlled through environment variables.
     * `deye_sg01hp3_generator` - tracks generation power and energy for each phase (1/2/3) and total (also works with Microinverter mode)
     * `deye_sg01hp3_timeofuse` - sg01hp3 time-of-use settings
     * `deye_sg01hp3_systemtime` - sg01hp3 system time register (required for DEYE_FEATURE_SET_TIME on sg01hp3)
+    * `deye_sg01hp3_settings` - sg01hp3-specific settings
     * `igen_dtsd422`- dtsd422 smart meter
     * `settings` - inverter settings, all types except micro
     * `settings_micro` - inverter settings for micro inverters
@@ -200,6 +201,7 @@ All configuration options are controlled through environment variables.
 * `DEYE_SET_TIME_INTERVAL` - how often to adjust the inverter/logger time (in seconds), defaults to `300`, i.e. every 5 minutes
 * `DEYE_FEATURE_ACTIVE_POWER_REGULATION` - enables active power regulation control over MQTT command topic
 * `DEYE_FEATURE_TIME_OF_USE` - enables Time Of Use feature control over MQTT
+* `DEYE_FEATURE_SOLAR_SELL` - enables Solar Sell control over MQTT
 * `DEYE_FEATURE_MULTI_INVERTER_DATA_AGGREGATOR` - enables multi-inverter data aggregation and publishing
 * `MQTT_HOST` - MQTT Broker IP address
 * `MQTT_PORT` - MQTT Broker port, , defaults to `1883`
@@ -268,6 +270,7 @@ It is possible to modify selected inverter settings over MQTT.
 | Setting                 |                             Topic                              | Unit | Value range | Feature flag                           |
 | ----------------------- | :------------------------------------------------------------: | ---- | :---------: | -------------------------------------- |
 | active power regulation | `{MQTT_TOPIC_PREFIX}/settings/active_power_regulation/command` | %    |    0-120    | `DEYE_FEATURE_ACTIVE_POWER_REGULATION` |
+| solar sell | `{MQTT_TOPIC_PREFIX}/settings/solar_sell/command` | boolean | 0,1 | `DEYE_FEATURE_SOLAR_SELL` |
 | time of use | `{MQTT_TOPIC_PREFIX}/timeofuse/selling` | number<sup>(1)</sup> | 0-255 |`DEYE_FEATURE_TIME_OF_USE` |
 | time of use | `{MQTT_TOPIC_PREFIX}/timeofuse/time/(1-6)/command` | time | 0000 - 2359 | `DEYE_FEATURE_TIME_OF_USE` |
 | time of use | `{MQTT_TOPIC_PREFIX}/timeofuse/power/(1-6)/command` | W | 0 - max power<sup>(2)</sup> | `DEYE_FEATURE_TIME_OF_USE` |

--- a/config.env.example
+++ b/config.env.example
@@ -29,6 +29,7 @@ DEYE_METRIC_GROUPS=string
 # DEYE_FEATURE_ACTIVE_POWER_REGULATION=false
 # DEYE_FEATURE_SET_TIME=false
 # DEYE_SET_TIME_INTERVAL=300
+# DEYE_FEATURE_SOLAR_SELL=false
 
 ## Sample multiinverter configuration with two loggers
 #

--- a/docs/metric_group_deye_sg01hp3_settings.md
+++ b/docs/metric_group_deye_sg01hp3_settings.md
@@ -1,0 +1,3 @@
+|Metric|MQTT topic suffix|Unit|Modbus address (dec)|Modbus address (hex)|Modbus data type|Scale factor|
+|---|---|:-:|:-:|:-:|:-:|:-:|
+|Solar sell enabled|`settings/solar_sell`|boolean (0, 1)|145|91|U_WORD|1|

--- a/src/deye_config.py
+++ b/src/deye_config.py
@@ -300,4 +300,6 @@ class DeyeConfig:
             active_processors.append("active_power_regulation")
         if DeyeEnv.boolean("DEYE_FEATURE_MULTI_INVERTER_DATA_AGGREGATOR", False):
             active_processors.append("multi_inverter_data_aggregator")
+        if DeyeEnv.boolean("DEYE_FEATURE_SOLAR_SELL", False):
+            active_processors.append("solar_sell")
         return active_processors

--- a/src/deye_processor_factory.py
+++ b/src/deye_processor_factory.py
@@ -25,6 +25,7 @@ from deye_mqtt_publisher import DeyeMqttPublisher
 from deye_set_time_processor import DeyeSetTimeProcessor
 from deye_timeofuse_service import DeyeTimeOfUseService
 from deye_active_power_regulation import DeyeActivePowerRegulationEventProcessor
+from deye_solar_sell import DeyeSolarSellEventProcessor
 from deye_sensor import Sensor
 from deye_plugin_loader import DeyePluginContext, DeyePluginLoader
 from deye_multi_inverter_data_aggregator import DeyeMultiInverterDataAggregator
@@ -62,6 +63,9 @@ class DeyeProcessorFactory:
         self.__append_processor(processors, DeyeTimeOfUseService(logger_config, self.__mqtt_client, sensors, modbus))
         self.__append_processor(
             processors, DeyeActivePowerRegulationEventProcessor(logger_config, self.__mqtt_client, sensors, modbus)
+        )
+        self.__append_processor(
+            processors, DeyeSolarSellEventProcessor(logger_config, self.__mqtt_client, sensors, modbus)
         )
         return processors
 

--- a/src/deye_sensors_deye_sg01hp3.py
+++ b/src/deye_sensors_deye_sg01hp3.py
@@ -32,6 +32,17 @@ deye_sg01hp3_system_time_62 = DateTimeSensor(
     groups=["deye_sg01hp3_systemtime"],
 )
 
+deye_sg01hp3_inverter_145 = SingleRegisterSensor(
+    "Solar sell enabled",
+    145,
+    1,
+    mqtt_topic_suffix="settings/solar_sell",
+    unit="",
+    print_format="{:.0f}",
+    signed=False,
+    groups=["deye_sg01hp3_settings"],
+)
+
 deye_sg01hp3_inverter_500 = EnumValueSensor(
     "Running status",
     500,
@@ -1092,6 +1103,7 @@ deye_sg01hp3_generator_537 = SingleRegisterSensor(
 
 deye_sg01hp3_sensors = [
     deye_sg01hp3_system_time_62,
+    deye_sg01hp3_inverter_145,
     deye_sg01hp3_inverter_500,
     deye_sg01hp3_inverter_552,
     deye_sg01hp3_solar_672,
@@ -1219,6 +1231,7 @@ deye_sg01hp3_sensors = [
 
 deye_sg01hp3_register_ranges = [
     SensorRegisterRange(group="deye_sg01hp3_systemtime", first_reg_address=62, last_reg_address=64),
+    SensorRegisterRange(group="deye_sg01hp3_settings", first_reg_address=145, last_reg_address=145),
     SensorRegisterRange(group="deye_sg01hp3", first_reg_address=500, last_reg_address=500),
     SensorRegisterRange(group="deye_sg01hp3", first_reg_address=552, last_reg_address=552),
     SensorRegisterRange(group="deye_sg01hp3_ups", first_reg_address=514, last_reg_address=558),

--- a/src/deye_solar_sell.py
+++ b/src/deye_solar_sell.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+
+from deye_mqtt import DeyeMqttClient
+from deye_modbus import DeyeModbus
+from deye_config import DeyeLoggerConfig
+from deye_events import DeyeEventProcessor
+from deye_sensor import Sensor
+from paho.mqtt.client import Client, MQTTMessage
+
+
+class DeyeSolarSellEventProcessor(DeyeEventProcessor):
+    """
+    Handles "solar sell" parameter modification requests received through MQTT
+    """
+
+    def __init__(
+        self, logger_config: DeyeLoggerConfig, mqtt_client: DeyeMqttClient, sensors: [Sensor], modbus: DeyeModbus
+    ):
+        self.__log = logger_config.logger_adapter(logging.getLogger(DeyeSolarSellEventProcessor.__name__))
+        self.__logger_config = logger_config
+        self.__mqtt_client = mqtt_client
+        self.__modbus = modbus
+        self.__solar_sell_topic_suffix = "settings/solar_sell"
+        self.__sensors = sensors
+        self.__solar_sell_sensor_reg_addr = None
+
+    def get_id(self):
+        return "solar_sell"
+
+    def get_description(self):
+        return "Solar Sell enable/disable over MQTT"
+
+    def initialize(self):
+        matching_sensors = [s for s in self.__sensors if s.mqtt_topic_suffix == self.__solar_sell_topic_suffix]
+        if len(matching_sensors) == 0:
+            self.__log.error("Solar sell sensor not found. Enable appropriate settings metric group.")
+            return
+        elif len(matching_sensors) > 1:
+            self.__log.error("Too many solar sell sensors found. Check your metric groups configuration.")
+            return
+        self.__solar_sell_sensor_reg_addr = matching_sensors[0].get_registers()[0]
+        self.__mqtt_client.subscribe_command_handler(
+            self.__logger_config.index, self.__solar_sell_topic_suffix, self.handle_command
+        )
+
+    def handle_command(self, client: Client, userdata, msg: MQTTMessage):
+        if self.__solar_sell_sensor_reg_addr is None:
+            return
+        try:
+            solar_sell_value = int(msg.payload.decode("utf-8").strip())
+        except Exception as e:
+            self.__log.error(f"Couldn't decode solar sell value: {msg.payload}, {e}")
+            return
+        if solar_sell_value not in (0, 1):
+            self.__log.error(f"Invalid value for solar sell setting: {solar_sell_value}")
+            return
+        self.__log.debug(f"Setting solar sell to {solar_sell_value}")
+        success = self.__modbus.write_register_uint(self.__solar_sell_sensor_reg_addr, solar_sell_value)
+        if success:
+            self.__log.info(f"Solar sell updated to {solar_sell_value}")
+        else:
+            self.__log.error(f"Failed setting solar sell to value: {solar_sell_value}")

--- a/tests/deye_solar_sell_test.py
+++ b/tests/deye_solar_sell_test.py
@@ -1,0 +1,152 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import patch
+
+from deye_solar_sell import DeyeSolarSellEventProcessor
+from deye_modbus import DeyeModbus
+from deye_mqtt import DeyeMqttClient
+from deye_config import DeyeConfig, DeyeMqttConfig, DeyeLoggerConfig
+from deye_sensor import Sensor, SingleRegisterSensor
+from paho.mqtt.client import Client, MQTTMessage
+
+
+class TestDeyeSolarSellEventProcessor(unittest.TestCase):
+
+    def setUp(self):
+        self.config = DeyeLoggerConfig(1234567890, "127.0.0.1", 8899)
+        self.sensor1 = SingleRegisterSensor(
+            "Solar sell enabled",
+            145,
+            1,
+            mqtt_topic_suffix="settings/solar_sell",
+            unit="",
+            print_format="{:.0f}",
+            signed=False,
+            groups=["test"],
+        )
+        self.sensor2 = SingleRegisterSensor(
+            "Solar sell enabled",
+            146,
+            1,
+            mqtt_topic_suffix="settings/solar_selll",
+            unit="",
+            print_format="{:.0f}",
+            signed=False,
+            groups=["test"],
+        )
+
+    @patch("deye_mqtt.DeyeMqttClient")
+    @patch("deye_modbus.DeyeModbus")
+    def test_init_with_no_sensor(
+            self,
+            mqtt_client_mock: DeyeMqttClient,
+            modbus_mock: DeyeModbus,
+    ):
+        # given
+        sensors = [self.sensor2]
+        processor = DeyeSolarSellEventProcessor(self.config, mqtt_client_mock, sensors, modbus_mock)
+
+        # when
+        processor.initialize()
+
+        # then
+        mqtt_client_mock.subscribe_command_handler.assert_not_called()
+
+    @patch("deye_mqtt.DeyeMqttClient")
+    @patch("deye_modbus.DeyeModbus")
+    def test_init_with_required_sensor(
+            self,
+            mqtt_client_mock: DeyeMqttClient,
+            modbus_mock: DeyeModbus,
+    ):
+        # given
+        sensors = [self.sensor1]
+        processor = DeyeSolarSellEventProcessor(self.config, mqtt_client_mock, sensors, modbus_mock)
+
+        # when
+        processor.initialize()
+
+        # then
+        mqtt_client_mock.subscribe_command_handler.assert_called_once()
+
+    @patch("deye_mqtt.DeyeMqttClient")
+    @patch("deye_modbus.DeyeModbus")
+    def test_handle_solar_sell_on(
+        self,
+        mqtt_client_mock: DeyeMqttClient,
+        modbus_mock: DeyeModbus,
+    ):
+        # given
+        sensors = [self.sensor1, self.sensor2]
+        processor = DeyeSolarSellEventProcessor(self.config, mqtt_client_mock, sensors, modbus_mock)
+        processor.initialize()
+
+        # and
+        msg = MQTTMessage()
+        msg.payload = b'1'
+
+        # when
+        processor.handle_command(None, None, msg)
+
+        # then
+        modbus_mock.write_register_uint.assert_called_with(145, 1)
+
+    @patch("deye_mqtt.DeyeMqttClient")
+    @patch("deye_modbus.DeyeModbus")
+    def test_handle_solar_sell_off(
+        self,
+        mqtt_client_mock: DeyeMqttClient,
+        modbus_mock: DeyeModbus,
+    ):
+        # given
+        sensors = [self.sensor1, self.sensor2]
+        processor = DeyeSolarSellEventProcessor(self.config, mqtt_client_mock, sensors, modbus_mock)
+        processor.initialize()
+
+        # and
+        msg = MQTTMessage()
+        msg.payload = b'0'
+
+        # when
+        processor.handle_command(None, None, msg)
+
+        # then
+        modbus_mock.write_register_uint.assert_called_with(145, 0)
+
+    @patch("deye_mqtt.DeyeMqttClient")
+    @patch("deye_modbus.DeyeModbus")
+    def test_handle_solar_sell_wrong_input_value(
+        self,
+        mqtt_client_mock: DeyeMqttClient,
+        modbus_mock: DeyeModbus,
+    ):
+        # given
+        sensors = [self.sensor1, self.sensor2]
+        processor = DeyeSolarSellEventProcessor(self.config, mqtt_client_mock, sensors, modbus_mock)
+        processor.initialize()
+
+        # and
+        msg = MQTTMessage()
+
+        for msg_payload in [b'', b'-5', b'1.2', b'100', b'test', b'Enable', b'X']:
+            msg.payload = msg_payload
+            with patch.object(processor, '_DeyeSolarSellEventProcessor__log') as mock_log:
+                processor.handle_command(None, None, msg)
+            modbus_mock.write_register_uint.assert_not_called()
+            mock_log.error.assert_called()


### PR DESCRIPTION
Adding the ability to control the "Solar Sell" setting which is for disabling/enabling surplus energy export to grid.
Currently it's being added only for SG01HP3 but can be extended to other inverters if we know which register they use for "solar sell".