### PR TITLE
RuntimeError: dictionary changed size during iteration

### DIFF
--- a/src/deye_mqtt.py
+++ b/src/deye_mqtt.py
@@ -65,8 +65,7 @@ class DeyeMqttClient:
         self.__command_handlers = {}
 
     def subscribe(self, topic: str, callback):
-        if not self.__mqtt_client.is_connected():
-            self.connect()
+        self.connect()
         self.__log.info("Subscribing to topic: %s", topic)
         result, mid = self.__mqtt_client.subscribe(topic, qos=1)
         if result != paho.MQTT_ERR_SUCCESS:


### PR DESCRIPTION
The crash happens inside the on_connect callback, when command handlers are re-subscribed while the internal dictionary of handlers is being modified from another thread.

Problem

On MQTT reconnect, __on_connect() calls:

__resubscribe_command_handlers()


The original implementation iterates directly over the mutable dictionary:

for mqtt_topic in self.__command_handlers:
    handler_method = self.__command_handlers[mqtt_topic]
    self.subscribe(mqtt_topic, handler_method)


At the same time, other threads may call subscribe_command_handler(), which modifies self.__command_handlers.

Since on_connect runs inside Paho MQTT’s network thread (loop_start()), this leads to a classic race condition and triggers:

RuntimeError: dictionary changed size during iteration

Solution

Iterate over a snapshot copy of the dictionary instead of the live structure. This makes the resubscription process safe even if handlers are added concurrently.

Fix applied
def __resubscribe_command_handlers(self):
    # Iterate over snapshot to avoid "dictionary changed size during iteration"
    for mqtt_topic, handler_method in list(self.__command_handlers.items()):
        self.subscribe(mqtt_topic, handler_method)

Additional Improvement

Avoid unnecessary calls to connect() inside subscribe() when the client is already connected:

def subscribe(self, topic: str, callback):
    if not self.__mqtt_client.is_connected():
        self.connect()
    self.__log.info("Subscribing to topic: %s", topic)
    result, mid = self.__mqtt_client.subscribe(topic, qos=1)
    if result != paho.MQTT_ERR_SUCCESS:
        self.__log.error("Failed to subscribe to topic %s", topic)
        return
    self.__mqtt_client.message_callback_add(topic, callback)