### PR TITLE
Reduce log level of "Active power regulation sensor not found" to INFO

### DIFF
--- a/src/deye_active_power_regulation.py
+++ b/src/deye_active_power_regulation.py
@@ -36,7 +36,7 @@ class DeyeActivePowerRegulationEventProcessor(DeyeEventProcessor):
         self.__active_power_regulation_topic_suffix = "settings/active_power_regulation"
         matching_sensors = [s for s in sensors if s.mqtt_topic_suffix == self.__active_power_regulation_topic_suffix]
         if len(matching_sensors) == 0:
-            self.__log.error("Active power regulation sensor not found. Enable appropriate settings metric group.")
+            self.__log.info("Active power regulation sensor not found. Enable appropriate settings metric group.")
             return
         elif len(matching_sensors) > 1:
             self.__log.error("Too many active power regulation sensors found. Check your metric groups configuration.")


### PR DESCRIPTION
This component is not required for normal operation. The message serves only as a hint to reconsider the configuration when the feature is intended to be used.                                                                                                          
                  
Logging it as ERROR causes false alerts in monitoring systems that treat all errors as actionable.
