### PR TITLE
Pass validated value to write_value instead of raw MQTT payload

### DIFF
--- a/src/deye_active_power_regulation.py
+++ b/src/deye_active_power_regulation.py
@@ -77,5 +77,5 @@ class DeyeActivePowerRegulationEventProcessor(DeyeEventProcessor):
             return
 
         self.__log.info("Setting active power regulation to %f", active_power_regulation_factor)
-        reg_addr, reg_value = self.__active_power_reg_sensor.write_value(msg.payload).popitem()
+        reg_addr, reg_value = self.__active_power_reg_sensor.write_value(str(active_power_regulation_factor)).popitem()
         self.__modbus.write_register(reg_addr, reg_value)


### PR DESCRIPTION
Pass the already-validated float to write_value instead of re-parsing the raw MQTT payload, ensuring that validation and write operation use the same value.