### PR TITLE
Fix type annotations, deprecated API, and typo

### DIFF
--- a/src/deye_at_connector.py
+++ b/src/deye_at_connector.py
@@ -99,7 +99,7 @@ class DeyeAtConnector(DeyeConnector):
             if not at_response or at_response.startswith(b"+ok=no data"):
                 return modbus_response
             if at_response.startswith(b"+ok="):
-                modbus_response = DeyeAtConnector.extract_modbus_respose(at_response)
+                modbus_response = DeyeAtConnector.extract_modbus_response(at_response)
                 self.__log.debug("Extracted Modbus response %s", modbus_response.hex())
 
             self.__deauthenticate(client_socket)
@@ -111,7 +111,7 @@ class DeyeAtConnector(DeyeConnector):
         return modbus_response
 
     @staticmethod
-    def extract_modbus_respose(at_cmd_response: bytes) -> bytes:
+    def extract_modbus_response(at_cmd_response: bytes) -> bytes:
         extracted_modus_response = at_cmd_response.replace(b"\x10", b"")[4:-4].decode("utf-8")
         if len(extracted_modus_response) > 4 and extracted_modus_response[-4:] == "0000":
             extracted_modus_response = extracted_modus_response[0:-4]

--- a/src/deye_at_connector.py
+++ b/src/deye_at_connector.py
@@ -45,12 +45,12 @@ class DeyeAtConnector(DeyeConnector):
             self.__reachable = False
             return
 
-    def __send_at_command(self, client_socket: socket, at_command: str) -> None:
+    def __send_at_command(self, client_socket: socket.socket, at_command: bytes) -> None:
         self.__log.debug("Sending AT command: %s", at_command)
         client_socket.sendto(at_command, (self.__logger_config.ip_address, self.__logger_config.port))
         time.sleep(0.1)
 
-    def __receive_at_response(self, client_socket: socket) -> str:
+    def __receive_at_response(self, client_socket: socket.socket) -> bytes | None:
         attempts = 5
         while attempts > 0:
             attempts = attempts - 1

--- a/src/deye_plugin_loader.py
+++ b/src/deye_plugin_loader.py
@@ -63,7 +63,7 @@ class DeyePluginLoader:
             except AttributeError:
                 self.__log.warn("Ignoring plugin '%s', because DeyePlugin class is not defined.", plugin_name)
 
-    def get_event_processors(self) -> [DeyeEventProcessor]:
+    def get_event_processors(self) -> list[DeyeEventProcessor]:
         event_processors = []
         for plugin in self.__plugins:
             event_processors.extend(plugin.get_event_processors())

--- a/src/deye_plugin_loader.py
+++ b/src/deye_plugin_loader.py
@@ -61,7 +61,7 @@ class DeyePluginLoader:
             try:
                 self.__plugins.append(plugin_module.DeyePlugin(plugin_context))
             except AttributeError:
-                self.__log.warn("Ignoring plugin '%s', because DeyePlugin class is not defined.", plugin_name)
+                self.__log.warning("Ignoring plugin '%s', because DeyePlugin class is not defined.", plugin_name)
 
     def get_event_processors(self) -> list[DeyeEventProcessor]:
         event_processors = []

--- a/src/deye_sensor.py
+++ b/src/deye_sensor.py
@@ -48,7 +48,7 @@ class Sensor:
         pass
 
     @abstractproperty
-    def groups(self) -> [str]:
+    def groups(self) -> list[str]:
         pass
 
     @abstractproperty
@@ -128,7 +128,7 @@ class DailyResetSensor(Sensor):
         return self.__delegate.print_format
 
     @property
-    def groups(self) -> [str]:
+    def groups(self) -> list[str]:
         return self.__delegate.groups
 
     @property
@@ -197,7 +197,7 @@ class AbstractSensor(Sensor):
         return self.__print_format
 
     @property
-    def groups(self) -> [str]:
+    def groups(self) -> list[str]:
         return self.__groups
 
     @property
@@ -562,7 +562,7 @@ class DateTimeSensor(AbstractSensor):
 
         return retval
 
-    def write_value(self, value: datetime) -> dict[int, bytearray]:
+    def write_value(self, value: datetime) -> dict[int, list[bytes]]:
 
         reg0_value = 256 * (value.year % 100) + value.month
         reg1_value = 256 * value.day + value.hour

--- a/src/deye_set_time_processor.py
+++ b/src/deye_set_time_processor.py
@@ -29,7 +29,7 @@ class DeyeSetTimeProcessor(DeyeEventProcessor):
     Set logger time when the logger becomes available online.
     """
 
-    def __init__(self, logger_config: DeyeLoggerConfig, interval: int, sensors: [Sensor], modbus: DeyeModbus):
+    def __init__(self, logger_config: DeyeLoggerConfig, interval: int, sensors: list[Sensor], modbus: DeyeModbus):
         self.__log = logger_config.logger_adapter(logging.getLogger(DeyeSetTimeProcessor.__name__))
         self.__interval = interval
         self.__modbus = modbus

--- a/tests/deye_at_connector_test.py
+++ b/tests/deye_at_connector_test.py
@@ -36,7 +36,7 @@ class DeyeAtConnectorTest(unittest.TestCase):
         )
 
         # when
-        modbus_response = DeyeAtConnector.extract_modbus_respose(at_cmd_response)
+        modbus_response = DeyeAtConnector.extract_modbus_response(at_cmd_response)
 
         # then
         assert modbus_response == bytearray.fromhex(
@@ -61,7 +61,7 @@ class DeyeAtConnectorTest(unittest.TestCase):
         )
 
         # when
-        modbus_response = DeyeAtConnector.extract_modbus_respose(at_cmd_response)
+        modbus_response = DeyeAtConnector.extract_modbus_response(at_cmd_response)
 
         # then
         assert modbus_response == bytearray.fromhex(


### PR DESCRIPTION
- Fix incorrect type annotations across multiple modules (`[T]` literals, `socket` vs `socket.socket`, wrong `str`/`bytes` return types)
- Replace deprecated `logger.warn()` with `logger.warning()`
- Rename `extract_modbus_respose` to `extract_modbus_response`
