### PR TITLE
Replace deprecated @abstractproperty with @property + @abstractmethod

### DIFF
--- a/src/deye_events.py
+++ b/src/deye_events.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import logging
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 from deye_observation import Observation
 
@@ -77,7 +77,7 @@ class DeyeLoggerStatusEvent(DeyeEvent):
 
 class DeyeEventList(list):
     """
-    An list of Deye Events
+    A list of Deye Events
     """
 
     def __init__(self, events: list[DeyeEvent] | None = None, logger_index: int = 0):
@@ -121,7 +121,7 @@ class DeyeEventList(list):
         Returns
         -------
         bool
-            True if both lists are containing the same events with same values
+            True if both lists contain the same events with same values
         """
         if self.logger_index != events.logger_index:
             return False
@@ -132,7 +132,7 @@ class DeyeEventList(list):
         return set_a == set_b
 
 
-class DeyeEventProcessor:
+class DeyeEventProcessor(ABC):
     """
     Processors "do something" with the events collected from the inverter.
     """
@@ -156,8 +156,7 @@ class DeyeEventProcessor:
         """
         return ""
 
-    @abstractmethod
-    def process(self, events: DeyeEventList):
+    def process(self, events: DeyeEventList) -> None:
         """
         Processes events representing changes of metric values
         """

--- a/src/deye_sensor.py
+++ b/src/deye_sensor.py
@@ -17,49 +17,57 @@
 
 import math
 from datetime import datetime
-from abc import abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 
 
-class Sensor:
+class Sensor(ABC):
     """
     Models solar inverter sensor.
 
     This is an abstract class. Method 'read_value' must be provided by the extending subclass.
     """
 
-    @abstractproperty
+    @property
     def reg_address(self) -> int:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def name(self) -> str:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def mqtt_topic_suffix(self) -> str:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def unit(self) -> str:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def print_format(self) -> str:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def groups(self) -> list[str]:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def data_type(self) -> str:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def scale_factor(self) -> float:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def is_readiness_check(self) -> bool:
         pass
 

--- a/tests/deye_events_test.py
+++ b/tests/deye_events_test.py
@@ -31,6 +31,9 @@ class FakeSensor(AbstractSensor):
     def read_value(self, registers):
         return self.value
 
+    def get_registers(self) -> list[int]:
+        return []
+
 
 class TestDeyeEventList(unittest.TestCase):
     def test_get_status_event(self):

--- a/tests/deye_inverter_state_test.py
+++ b/tests/deye_inverter_state_test.py
@@ -38,6 +38,9 @@ class FakeSensor(AbstractSensor):
     def is_readiness_check(self):
         return self.__is_readiness_check
 
+    def get_registers(self) -> list[int]:
+        return []
+
 
 class TestInverterState(unittest.TestCase):
     def test_no_last_observation(self):

--- a/tests/deye_sensor_test.py
+++ b/tests/deye_sensor_test.py
@@ -40,6 +40,9 @@ class FakeSensor(AbstractSensor):
     def read_value(self, registers):
         return self.value
 
+    def get_registers(self) -> list[int]:
+        return []
+
 
 class DeyeSensorTest(unittest.TestCase):
     def test_sum_sensor_returns_sum_when_all_inputs_are_given(self):


### PR DESCRIPTION
`abstractproperty` has been deprecated since Python 3.3. The stacked decorator form makes the two concerns explicit: `@property` defines the access style, `@abstractmethod` enforces implementation in subclasses.

Add `ABC` as base class to `Sensor` and `DeyeEventProcessor` to actually activate enforcement — without `ABC` inheritance, `@abstractmethod` has no effect and Python never raises `TypeError` for missing implementations.

`reg_address` and `process` are not implemented by all subclasses by design, so their `@abstractmethod` is removed in favour of a no-op default. `get_registers` remains abstract as it is actively used in production code; the three `FakeSensor` test stubs receive a minimal implementation returning an empty list

Closes #287 