### PR TITLE
Cap MQTT reconnect backoff to avoid stalls after broker restart

### DIFF
--- a/src/deye_mqtt.py
+++ b/src/deye_mqtt.py
@@ -64,6 +64,8 @@ class DeyeMqttClient:
         self.__publish_lock = threading.RLock()
         self.__command_handlers = {}
         self.__loop_started = False
+        # reconnect promptly after a broker restart.
+        self.__mqtt_client.reconnect_delay_set(min_delay=1, max_delay=2)
 
     def subscribe(self, topic: str, callback):
         self.connect()


### PR DESCRIPTION
Paho's default exponential backoff grows to 128s, so a caller waiting in `connect()` can stall for over a minute even after the broker is reachable again.
