### PR TITLE
Reduce log level of "sensor not found" to INFO in solar sell and workmode

### DIFF
--- a/src/deye_set_workmode_processor.py
+++ b/src/deye_set_workmode_processor.py
@@ -50,7 +50,7 @@ class DeyeWorkmodeEventProcessor(DeyeEventProcessor):
     def initialize(self):
         matching_sensors = [s for s in self.__sensors if s.mqtt_topic_suffix == self.__workmode_topic_suffix]
         if len(matching_sensors) == 0:
-            self.__log.error("WorkMode sensor not found. Enable appropriate settings metric group.")
+            self.__log.info("WorkMode sensor not found. Enable appropriate settings metric group.")
             return
         elif len(matching_sensors) > 1:
             self.__log.error("Too many WorkChange Mode sensors found. Check your metric groups configuration.")

--- a/src/deye_solar_sell.py
+++ b/src/deye_solar_sell.py
@@ -50,7 +50,7 @@ class DeyeSolarSellEventProcessor(DeyeEventProcessor):
     def initialize(self):
         matching_sensors = [s for s in self.__sensors if s.mqtt_topic_suffix == self.__solar_sell_topic_suffix]
         if len(matching_sensors) == 0:
-            self.__log.error("Solar sell sensor not found. Enable appropriate settings metric group.")
+            self.__log.info("Solar sell sensor not found. Enable appropriate settings metric group.")
             return
         elif len(matching_sensors) > 1:
             self.__log.error("Too many solar sell sensors found. Check your metric groups configuration.")


### PR DESCRIPTION
These components are not required for normal operation. The message serves only as a hint to reconsider the configuration when the feature is intended to be used.

Follows: 43bc5bb ('Reduce log level of "Active power regulation sensor not found" to INFO')