### PR TITLE
Reduce "sensor not found" log level to INFO in remaining components

### DIFF
--- a/src/deye_set_batterysettings_processor.py
+++ b/src/deye_set_batterysettings_processor.py
@@ -52,7 +52,7 @@ class DeyeBatterySettingsEventProcessor(DeyeEventProcessor):
             s for s in self.__sensors if s.mqtt_topic_suffix.startswith(self.__battery_settings_topic_suffix)
         ]
         if not matching_sensors:
-            self.__log.warning("BatterySettings sensors not found. Enable appropriate settings metric group.")
+            self.__log.info("BatterySettings sensors not found. Enable appropriate settings metric group.")
             return
         for sensor in matching_sensors:
             reg = sensor.get_registers()[0]

--- a/src/deye_solar_sell_max_power.py
+++ b/src/deye_solar_sell_max_power.py
@@ -52,7 +52,7 @@ class DeyeSolarSellMaxPowerEventProcessor(DeyeEventProcessor):
             s for s in self.__sensors if s.mqtt_topic_suffix == self.__solar_sell_max_power_topic_suffix
         ]
         if len(matching_sensors) == 0:
-            self.__log.error("Solar sell max power sensor not found. Enable appropriate settings metric group.")
+            self.__log.info("Solar sell max power sensor not found. Enable appropriate settings metric group.")
             return
         elif len(matching_sensors) > 1:
             self.__log.error("Too many solar sell max power sensors found. Check your metric groups configuration.")


### PR DESCRIPTION
deye_solar_sell_max_power and deye_set_batterysettings_processor were missed when the log level was reduced for identical "sensor not found" messages in other optional components.

Follows: c91bfb9 ('Reduce log level of "sensor not found" to INFO in solar sell and workmode')
Follows: 43bc5bb ('Reduce log level of "Active power regulation sensor not found" to INFO')