### PR TITLE
SG02LP1 BMS: adjust labels for charge/discharge voltage

### DIFF
--- a/docs/metric_group_deye_sg02lp1_bms.md
+++ b/docs/metric_group_deye_sg02lp1_bms.md
@@ -1,7 +1,7 @@
 |Metric|MQTT topic suffix|Unit|Modbus address (dec)|Modbus address (hex)|Modbus data type|Scale factor|
 |---|---|:-:|:-:|:-:|:-:|:-:|
-|BMS1 Charging Voltage|`bms/1/charging_voltage`|V|312|138|U_WORD|0.01|
-|BMS1 Discharge Voltage|`bms/1/discharge_voltage`|V|313|139|U_WORD|0.01|
+|BMS1 Charge End Voltage|`bms/1/charging_voltage`|V|312|138|U_WORD|0.01|
+|BMS1 Discharge End Voltage|`bms/1/discharge_voltage`|V|313|139|U_WORD|0.01|
 |BMS1 Charge Current Limit|`bms/1/charge_current_limit`|A|314|13a|U_WORD|1|
 |BMS1 Discharge Current Limit|`bms/1/discharge_current_limit`|A|315|13b|U_WORD|1|
 |BMS1 SOC|`bms/1/soc`|%|316|13c|U_WORD|1|

--- a/src/deye_sensors_deye_sg02lp1.py
+++ b/src/deye_sensors_deye_sg02lp1.py
@@ -614,7 +614,7 @@ deye_sg02lp1_time_of_use_267 = SingleRegisterSensor(
 )
 
 deye_sg02lp1_bms_312 = SingleRegisterSensor(
-    "BMS1 Charging Voltage",
+    "BMS1 Charge End Voltage",
     312,
     0.01,
     mqtt_topic_suffix="bms/1/charging_voltage",
@@ -624,7 +624,7 @@ deye_sg02lp1_bms_312 = SingleRegisterSensor(
 )
 
 deye_sg02lp1_bms_313 = SingleRegisterSensor(
-    "BMS1 Discharge Voltage",
+    "BMS1 Discharge End Voltage",
     313,
     0.01,
     mqtt_topic_suffix="bms/1/discharge_voltage",


### PR DESCRIPTION
This renames the description for SG02LP1 BMS properties registers `138`⇔`312` and `139`⇔`313` to match the description under https://www.deyecloud.com/:

<img width="573" height="119" alt="image" src="https://github.com/user-attachments/assets/2e87bf55-6a5e-468d-a330-9ddd9c42b749" />
